### PR TITLE
Cleanup: Convert tabs to spaces. Remove trailing spaces.

### DIFF
--- a/lib/DNS/Base.py
+++ b/lib/DNS/Base.py
@@ -17,7 +17,7 @@ import asyncore
 # is important to prevent spurious results from lost packets, and malicious
 # cache poisoning.  This doesn't matter if you are behind a caching nameserver
 # or your app is a primary DNS server only. To install your own generator,
-# replace DNS.Base.random.  SystemRandom uses /dev/urandom or similar source.  
+# replace DNS.Base.random.  SystemRandom uses /dev/urandom or similar source.
 #
 try:
   from random import SystemRandom
@@ -44,7 +44,7 @@ def ParseResolvConf(resolv_path="/etc/resolv.conf"):
         if not line or line[0]==';' or line[0]=='#':
             continue
         fields=string.split(line)
-        if len(fields) < 2: 
+        if len(fields) < 2:
             continue
         if fields[0]=='domain' and len(fields) > 1:
             defaults['domain']=fields[1]
@@ -161,7 +161,7 @@ class DnsRequest:
                 source_port = random.randint(1024,65535)
                 self.s.bind(('', source_port))
                 break
-            except socket.error, msg: 
+            except socket.error, msg:
                 # Error 98, 'Address already in use'
                 if msg[0] != 98: raise
 

--- a/lib/backendDataFile.py
+++ b/lib/backendDataFile.py
@@ -2,25 +2,25 @@ from common import *
 import os, json
 
 class backendData():
-	def __init__(self, filename):
-		self.datafile = filename
-		
-	def getAllNames(self):
-		if not os.path.exists(self.datafile):
-			return True, 'Config file "' + self.datafile + '" doesn\'t exist.'
+    def __init__(self, filename):
+        self.datafile = filename
 
-		data = open(app['path']['app'] + self.datafile).read()
-		try:
-			data = json.loads(data)
-		except:
-			return True, 'Data not in json in "' + self.datafile + '".'
+    def getAllNames(self):
+        if not os.path.exists(self.datafile):
+            return True, 'Config file "' + self.datafile + '" doesn\'t exist.'
 
-		datas = {}
-		for name in data:
-			datas[name['name']] = name
+        data = open(app['path']['app'] + self.datafile).read()
+        try:
+            data = json.loads(data)
+        except:
+            return True, 'Data not in json in "' + self.datafile + '".'
 
-		return None, datas
+        datas = {}
+        for name in data:
+            datas[name['name']] = name
 
-	def getName(self, name):
-		return False
+        return None, datas
+
+    def getName(self, name):
+        return False
 

--- a/lib/backendDataNamecoin.py
+++ b/lib/backendDataNamecoin.py
@@ -3,46 +3,46 @@ import rpcClient
 import ConfigParser, StringIO
 
 class backendData():
-	def __init__(self, conf):
-		self.conf = conf
+    def __init__(self, conf):
+        self.conf = conf
 
-	rpc = None
+    rpc = None
 
-	def _loadRPCConfig(self):
-		conf = ConfigParser.SafeConfigParser()
-		ini_str = '[r]\n' + open(self.conf).read()
-		ini_fp = StringIO.StringIO(ini_str)
-		conf.readfp(ini_fp)
+    def _loadRPCConfig(self):
+        conf = ConfigParser.SafeConfigParser()
+        ini_str = '[r]\n' + open(self.conf).read()
+        ini_fp = StringIO.StringIO(ini_str)
+        conf.readfp(ini_fp)
 
-		host = '127.0.0.1'
-		port = 8336
-		user = ''
-		password = ''
+        host = '127.0.0.1'
+        port = 8336
+        user = ''
+        password = ''
 
-		if conf.has_option('r', 'rpcconnect'):
-			host = conf.get('r', 'rpcconnect')
-		if conf.has_option('r', 'rpcport'):
-			port = conf.get('r', 'rpcport')
-		if conf.has_option('r', 'rpcuser'):
-			user = conf.get('r', 'rpcuser')
-		if conf.has_option('r', 'rpcpassword'):
-			password = conf.get('r', 'rpcpassword')
-		
-		self.rpc = rpcClient.rpcClientNamecoin(host, port, user, password)
+        if conf.has_option('r', 'rpcconnect'):
+            host = conf.get('r', 'rpcconnect')
+        if conf.has_option('r', 'rpcport'):
+            port = conf.get('r', 'rpcport')
+        if conf.has_option('r', 'rpcuser'):
+            user = conf.get('r', 'rpcuser')
+        if conf.has_option('r', 'rpcpassword'):
+            password = conf.get('r', 'rpcpassword')
 
-	def getAllNames(self):
-		datas = {}
-		error, data = self._rpcSend(["name_filter", app['plugins']['data'].conf['name_filter']])
-		for name in data:
-			datas[name['name']] = name
-		return error, datas
+        self.rpc = rpcClient.rpcClientNamecoin(host, port, user, password)
 
-	def getName(self, name):
-		return self._rpcSend(["name_show", name])
-	
-	def _rpcSend(self, rpcCmd):
-		if app['debug']: print "BackendDataNamecoin:", rpcCmd
-		if self.rpc is None:
-			self._loadRPCConfig()
-		return self.rpc.sendJson(rpcCmd)
-	
+    def getAllNames(self):
+        datas = {}
+        error, data = self._rpcSend(["name_filter", app['plugins']['data'].conf['name_filter']])
+        for name in data:
+            datas[name['name']] = name
+        return error, datas
+
+    def getName(self, name):
+        return self._rpcSend(["name_show", name])
+
+    def _rpcSend(self, rpcCmd):
+        if app['debug']: print "BackendDataNamecoin:", rpcCmd
+        if self.rpc is None:
+            self._loadRPCConfig()
+        return self.rpc.sendJson(rpcCmd)
+

--- a/lib/console.py
+++ b/lib/console.py
@@ -1,26 +1,26 @@
 def getTerminalSize():
-	import os
-	env = os.environ
-	def ioctl_GWINSZ(fd):
-		try:
-			import fcntl, termios, struct, os
-			cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ,
-		'1234'))
-		except:
-			return None
-		return cr
-	cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
-	if not cr:
-		try:
-			fd = os.open(os.ctermid(), os.O_RDONLY)
-			cr = ioctl_GWINSZ(fd)
-			os.close(fd)
-		except:
-			pass
-	if not cr:
-		try:
-			cr = (env['LINES'], env['COLUMNS'])
-		except:
-			cr = (25, 80)
-	return int(cr[1]), int(cr[0])
+    import os
+    env = os.environ
+    def ioctl_GWINSZ(fd):
+        try:
+            import fcntl, termios, struct, os
+            cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ,
+        '1234'))
+        except:
+            return None
+        return cr
+    cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
+    if not cr:
+        try:
+            fd = os.open(os.ctermid(), os.O_RDONLY)
+            cr = ioctl_GWINSZ(fd)
+            os.close(fd)
+        except:
+            pass
+    if not cr:
+        try:
+            cr = (env['LINES'], env['COLUMNS'])
+        except:
+            cr = (25, 80)
+    return int(cr[1]), int(cr[0])
 

--- a/lib/daemonize.py
+++ b/lib/daemonize.py
@@ -4,7 +4,7 @@ Configurable daemon behaviors:
 
    1.) The current working directory set to the "/" directory.
    2.) The current file creation mode mask set to 0.
-   3.) Close all open files (1024). 
+   3.) Close all open files (1024).
    4.) Redirect standard I/O streams to "/dev/null".
 
 A failed call to fork() now raises an exception.
@@ -56,7 +56,7 @@ def createDaemon():
    except OSError, e:
       raise Exception, "%s [%d]" % (e.strerror, e.errno)
 
-   if (pid == 0):	# The first child.
+   if (pid == 0):    # The first child.
       # To become the session leader of this new session and the process group
       # leader of the new process group, we call os.setsid().  The process is
       # also guaranteed not to have a controlling terminal.
@@ -100,11 +100,11 @@ def createDaemon():
          # based systems).  This second fork guarantees that the child is no
          # longer a session leader, preventing the daemon from ever acquiring
          # a controlling terminal.
-         pid = os.fork()	# Fork a second child.
+         pid = os.fork()    # Fork a second child.
       except OSError, e:
          raise Exception, "%s [%d]" % (e.strerror, e.errno)
 
-      if (pid == 0):	# The second child.
+      if (pid == 0):    # The second child.
          # Since the current working directory may be a mounted filesystem, we
          # avoid the issue of not being able to unmount the filesystem at
          # shutdown time by changing it to the root directory.
@@ -114,7 +114,7 @@ def createDaemon():
          os.umask(UMASK)
       else:
          # exit() or _exit()?  See below.
-         os._exit(0)	# Exit parent (the first child) of the second child.
+         os._exit(0)    # Exit parent (the first child) of the second child.
    else:
       # exit() or _exit()?
       # _exit is like exit(), but it doesn't call any functions registered
@@ -123,7 +123,7 @@ def createDaemon():
       # streams to be flushed twice and any temporary files may be unexpectedly
       # removed.  It's therefore recommended that child branches of a fork()
       # and the parent branch(es) of a daemon use _exit().
-      os._exit(0)	# Exit parent of the first child.
+      os._exit(0)    # Exit parent of the first child.
 
    # Close all open file descriptors.  This prevents the child from keeping
    # open any file descriptors inherited from the parent.  There is a variety
@@ -151,16 +151,16 @@ def createDaemon():
    # that can be opened by this process.  If there is not limit on the
    # resource, use the default value.
    #
-   import resource		# Resource usage information.
+   import resource        # Resource usage information.
    maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
    if (maxfd == resource.RLIM_INFINITY):
       maxfd = MAXFD
-  
+
    # Iterate through and close all file descriptors.
    for fd in range(0, maxfd):
       try:
          os.close(fd)
-      except OSError:	# ERROR, fd wasn't open to begin with (ignored)
+      except OSError:    # ERROR, fd wasn't open to begin with (ignored)
          pass
 
    # Redirect the standard I/O file descriptors to the specified file.  Since
@@ -170,11 +170,11 @@ def createDaemon():
 
    # This call to open is guaranteed to return the lowest file descriptor,
    # which will be 0 (stdin), since it was closed above.
-   os.open(REDIRECT_TO, os.O_RDWR)	# standard input (0)
+   os.open(REDIRECT_TO, os.O_RDWR)    # standard input (0)
 
    # Duplicate standard input to standard output and standard error.
-   os.dup2(0, 1)			# standard output (1)
-   os.dup2(0, 2)			# standard error (2)
+   os.dup2(0, 1)            # standard output (1)
+   os.dup2(0, 2)            # standard error (2)
 
    return(0)
 
@@ -186,7 +186,7 @@ def createDaemon():
    # executed with superuser privileges.  The file will contain the following
    # daemon related process parameters: return code, process ID, parent
    # process group ID, session ID, user ID, effective user ID, real group ID,
-   # and the effective group ID.  Notice the relationship between the daemon's 
+   # and the effective group ID.  Notice the relationship between the daemon's
    # process ID, process group ID, and its parent's process ID.
 
 #   procParams = """

--- a/lib/dnsServer/__init__.py
+++ b/lib/dnsServer/__init__.py
@@ -11,17 +11,17 @@
 # Software is furnished to do so, subject to the following
 # conditions:
 #
-#	 The above copyright notice and this permission notice shall be
-#	 included in all copies or substantial portions of the Software.
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the Software.
 #
-#	 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-#	 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-#	 OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-#	 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-#	 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-#	 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-#	 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-#	 OTHER DEALINGS IN THE SOFTWARE.
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
 #
 # Modified by Khalahan in order to include it in nmcontrol
 # Modified by sonicrules1234 (Westly Ward) in order to have it work as a dns server for all domains rather than just one
@@ -39,241 +39,241 @@ from utils import *
 from common import *
 
 class DnsError(Exception):
-	pass
+    pass
 
 class DnsServer(threading.Thread):
-	daemon = True;
-	running = True
-	udps = None
-	
-	def run(self):
-		self.serve()
+    daemon = True;
+    running = True
+    udps = None
 
-	def serve(self):
-		self.udps = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-		self.udps.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-		udps = self.udps
-		listen_host = app['services']['dns'].conf['host']
-		listen_port = int(app['services']['dns'].conf['port'])
-		try:
-			udps.bind((listen_host, listen_port))
-		except socket.error as e:
-			print "ERROR: Unable to start DNS server (%s)" % e
-		#ns_resource_records, ar_resource_records = compute_name_server_resources(_name_servers)
-		ns_resource_records = ar_resource_records = []
-		while self.running:
-			try:
-				req_pkt, src_addr = udps.recvfrom(512)   # max UDP DNS pkt size
-			except socket.error:
-				continue
-			qid = None
-			try:
-				exception_rcode = None
-				try:
-					qid, question, qtype, qclass = parse_request(req_pkt)
-				except:
-					exception_rcode = 1
-					if not self.running:
-						continue
-					raise Exception("could not parse query")
-				question = map(lambda x: x.lower(), question)
-				found = False
-				source_module = __import__("namecoindns", globals(), locals(), [])
-				source_instance = source_module.Source()
-				for config in [True]:
-					#if question[1:] == config['domain']:
-						#query = question[0]
-					#elif question == config['domain']:
-						#query = ''
-					#else:
-					#	continue
-					#print question
-					#if len(question) == 2 :
-					query = ""   
-					#query = question.split(".")
-					rcode, an_resource_records = source_instance.get_response(query, ".".join(question), qtype, qclass, src_addr)
-					#if rcode == 0 and 'filters' in config:
-					#	for f in config['filters']:
-					#		an_resource_records = f.filter(query, config['domain'], qtype, qclass, src_addr, an_resource_records)
-					resp_pkt = format_response(qid, question, qtype, qclass, rcode, an_resource_records, ns_resource_records, ar_resource_records)
-					found = True
-					break
-				if not found:
-					exception_rcode = 3
-					raise Exception("query is not for our domain: %s" % ".".join(question))
-			except:
-				if app['debug']: traceback.print_exc()
-				if not self.running:
-					continue
-				if qid:
-					if exception_rcode is None:
-						exception_rcode = 2
-					resp_pkt = format_response(qid, question, qtype, qclass, exception_rcode, [], [], [])
-				else:
-					continue
-			udps.sendto(resp_pkt, src_addr)
-	
-	def stop(self):
-		self.running = False
-		try:
-			self.udps.shutdown(socket.SHUT_RDWR)
-			self.udps.close()
-		except:
-			pass
+    def run(self):
+        self.serve()
+
+    def serve(self):
+        self.udps = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.udps.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        udps = self.udps
+        listen_host = app['services']['dns'].conf['host']
+        listen_port = int(app['services']['dns'].conf['port'])
+        try:
+            udps.bind((listen_host, listen_port))
+        except socket.error as e:
+            print "ERROR: Unable to start DNS server (%s)" % e
+        #ns_resource_records, ar_resource_records = compute_name_server_resources(_name_servers)
+        ns_resource_records = ar_resource_records = []
+        while self.running:
+            try:
+                req_pkt, src_addr = udps.recvfrom(512)   # max UDP DNS pkt size
+            except socket.error:
+                continue
+            qid = None
+            try:
+                exception_rcode = None
+                try:
+                    qid, question, qtype, qclass = parse_request(req_pkt)
+                except:
+                    exception_rcode = 1
+                    if not self.running:
+                        continue
+                    raise Exception("could not parse query")
+                question = map(lambda x: x.lower(), question)
+                found = False
+                source_module = __import__("namecoindns", globals(), locals(), [])
+                source_instance = source_module.Source()
+                for config in [True]:
+                    #if question[1:] == config['domain']:
+                        #query = question[0]
+                    #elif question == config['domain']:
+                        #query = ''
+                    #else:
+                    #    continue
+                    #print question
+                    #if len(question) == 2 :
+                    query = ""
+                    #query = question.split(".")
+                    rcode, an_resource_records = source_instance.get_response(query, ".".join(question), qtype, qclass, src_addr)
+                    #if rcode == 0 and 'filters' in config:
+                    #    for f in config['filters']:
+                    #        an_resource_records = f.filter(query, config['domain'], qtype, qclass, src_addr, an_resource_records)
+                    resp_pkt = format_response(qid, question, qtype, qclass, rcode, an_resource_records, ns_resource_records, ar_resource_records)
+                    found = True
+                    break
+                if not found:
+                    exception_rcode = 3
+                    raise Exception("query is not for our domain: %s" % ".".join(question))
+            except:
+                if app['debug']: traceback.print_exc()
+                if not self.running:
+                    continue
+                if qid:
+                    if exception_rcode is None:
+                        exception_rcode = 2
+                    resp_pkt = format_response(qid, question, qtype, qclass, exception_rcode, [], [], [])
+                else:
+                    continue
+            udps.sendto(resp_pkt, src_addr)
+
+    def stop(self):
+        self.running = False
+        try:
+            self.udps.shutdown(socket.SHUT_RDWR)
+            self.udps.close()
+        except:
+            pass
 
 def compute_name_server_resources(name_servers):
-	ns = []
-	ar = []
-	for name_server, ip, ttl in name_servers:
-		ns.append({'qtype':2, 'qclass':1, 'ttl':ttl, 'rdata':labels2str(name_server)})
-		ar.append({'qtype':1, 'qclass':1, 'ttl':ttl, 'rdata':struct.pack("!I", ip)})
-	return ns, ar
-		
+    ns = []
+    ar = []
+    for name_server, ip, ttl in name_servers:
+        ns.append({'qtype':2, 'qclass':1, 'ttl':ttl, 'rdata':labels2str(name_server)})
+        ar.append({'qtype':1, 'qclass':1, 'ttl':ttl, 'rdata':struct.pack("!I", ip)})
+    return ns, ar
+
 def parse_request(packet):
-	hdr_len = 12
-	header = packet[:hdr_len]
-	qid, flags, qdcount, _, _, _ = struct.unpack('!HHHHHH', header)
-	qr = (flags >> 15) & 0x1
-	opcode = (flags >> 11) & 0xf
-	rd = (flags >> 8) & 0x1
-	#print "qid", qid, "qdcount", qdcount, "qr", qr, "opcode", opcode, "rd", rd
-	if qr != 0 or opcode != 0 or qdcount == 0:
-		raise DnsError("Invalid query")
-	body = packet[hdr_len:]
-	labels = []
-	offset = 0
-	while True:
-		label_len, = struct.unpack('!B', body[offset:offset+1])
-		offset += 1
-		if label_len & 0xc0:
-			raise DnsError("Invalid label length %d" % label_len)
-		if label_len == 0:
-			break
-		label = body[offset:offset+label_len]
-		offset += label_len
-		labels.append(label)
-	qtype, qclass= struct.unpack("!HH", body[offset:offset+4])
-	if qclass != 1:
-		raise DnsError("Invalid class: " + qclass)
-	return (qid, labels, qtype, qclass)
+    hdr_len = 12
+    header = packet[:hdr_len]
+    qid, flags, qdcount, _, _, _ = struct.unpack('!HHHHHH', header)
+    qr = (flags >> 15) & 0x1
+    opcode = (flags >> 11) & 0xf
+    rd = (flags >> 8) & 0x1
+    #print "qid", qid, "qdcount", qdcount, "qr", qr, "opcode", opcode, "rd", rd
+    if qr != 0 or opcode != 0 or qdcount == 0:
+        raise DnsError("Invalid query")
+    body = packet[hdr_len:]
+    labels = []
+    offset = 0
+    while True:
+        label_len, = struct.unpack('!B', body[offset:offset+1])
+        offset += 1
+        if label_len & 0xc0:
+            raise DnsError("Invalid label length %d" % label_len)
+        if label_len == 0:
+            break
+        label = body[offset:offset+label_len]
+        offset += label_len
+        labels.append(label)
+    qtype, qclass= struct.unpack("!HH", body[offset:offset+4])
+    if qclass != 1:
+        raise DnsError("Invalid class: " + qclass)
+    return (qid, labels, qtype, qclass)
 
 def format_response(qid, question, qtype, qclass, rcode, an_resource_records, ns_resource_records, ar_resource_records):
-	resources = []
-	resources.extend(an_resource_records)
-	num_an_resources = len(an_resource_records)
-	num_ns_resources = num_ar_resources = 0
-	if rcode == 0:
-		resources.extend(ns_resource_records)
-		resources.extend(ar_resource_records)
-		num_ns_resources = len(ns_resource_records)
-		num_ar_resources = len(ar_resource_records)
-	pkt = format_header(qid, rcode, num_an_resources, num_ns_resources, num_ar_resources)
-	pkt += format_question(question, qtype, qclass)
-	for resource in resources:
-		pkt += format_resource(resource, question)
-	return pkt
+    resources = []
+    resources.extend(an_resource_records)
+    num_an_resources = len(an_resource_records)
+    num_ns_resources = num_ar_resources = 0
+    if rcode == 0:
+        resources.extend(ns_resource_records)
+        resources.extend(ar_resource_records)
+        num_ns_resources = len(ns_resource_records)
+        num_ar_resources = len(ar_resource_records)
+    pkt = format_header(qid, rcode, num_an_resources, num_ns_resources, num_ar_resources)
+    pkt += format_question(question, qtype, qclass)
+    for resource in resources:
+        pkt += format_resource(resource, question)
+    return pkt
 
 def format_header(qid, rcode, ancount, nscount, arcount):
-	flags = 0
-	flags |= (1 << 15)
-	flags |= (1 << 10)
-	flags |= (rcode & 0xf)
-	hdr = struct.pack("!HHHHHH", qid, flags, 1, ancount, nscount, arcount)
-	return hdr
+    flags = 0
+    flags |= (1 << 15)
+    flags |= (1 << 10)
+    flags |= (rcode & 0xf)
+    hdr = struct.pack("!HHHHHH", qid, flags, 1, ancount, nscount, arcount)
+    return hdr
 
 def format_question(question, qtype, qclass):
-	q = labels2str(question)
-	q += struct.pack("!HH", qtype, qclass)
-	return q
+    q = labels2str(question)
+    q += struct.pack("!HH", qtype, qclass)
+    return q
 
 def format_resource(resource, question):
-	r = ''
-	r += labels2str(question)
-	r += struct.pack("!HHIH", resource['qtype'], resource['qclass'], resource['ttl'], len(resource['rdata']))
-	r += resource['rdata']
-	return r
+    r = ''
+    r += labels2str(question)
+    r += struct.pack("!HHIH", resource['qtype'], resource['qclass'], resource['ttl'], len(resource['rdata']))
+    r += resource['rdata']
+    return r
 
 #def read_config():
-#	for config_file in config_files:
-#		config_files[config_file] = config = {}
-#		config_parser = ConfigParser.SafeConfigParser()
-#		try:
-#			config_parser.read(config_file)
-#			config_values = config_parser.items("default")	
-#		except:
-#			die("Error reading config file %s\n" % config_file)
+#    for config_file in config_files:
+#        config_files[config_file] = config = {}
+#        config_parser = ConfigParser.SafeConfigParser()
+#        try:
+#            config_parser.read(config_file)
+#            config_values = config_parser.items("default")
+#        except:
+#            die("Error reading config file %s\n" % config_file)
 #
-#		for var, value in config_values:
-#			if var == "domain":
-#				config['domain'] = value.split(".")
-#			elif var == "name servers":
-#				config['name_servers'] = []
-#				split_name_servers = value.split(":")
-#				num_split_name_servers = len(split_name_servers)
-#				for i in range(0,num_split_name_servers,3):
-#					server = split_name_servers[i]
-#					ip = split_name_servers[i+1]
-#					ttl = int(split_name_servers[i+2])
-#					config['name_servers'].append((server.split("."), ipstr2int(ip), ttl))
-#			elif var == 'source':
-#				module_and_args = value.split(":")
-#				module = module_and_args[0]
-#				args = module_and_args[1:]
-#				source_module = __import__(module, {}, {}, [''])
-#				source_instance = source_module.Source(*args)
-#				config['source'] = source_instance
-#			elif var == 'filters':
-#				config['filters'] = []
-#				for module_and_args_str in value.split():
-#					module_and_args = module_and_args_str.split(":")
-#					module = module_and_args[0]
-#					args = module_and_args[1:]
-#					filter_module = __import__(module, {}, {}, [''])			
-#					filter_instance = filter_module.Filter(*args)
-#					config['filters'].append(filter_instance)
-#			else:
-#				die("unrecognized paramter in conf file %s: %s\n" % (config_file, var))
+#        for var, value in config_values:
+#            if var == "domain":
+#                config['domain'] = value.split(".")
+#            elif var == "name servers":
+#                config['name_servers'] = []
+#                split_name_servers = value.split(":")
+#                num_split_name_servers = len(split_name_servers)
+#                for i in range(0,num_split_name_servers,3):
+#                    server = split_name_servers[i]
+#                    ip = split_name_servers[i+1]
+#                    ttl = int(split_name_servers[i+2])
+#                    config['name_servers'].append((server.split("."), ipstr2int(ip), ttl))
+#            elif var == 'source':
+#                module_and_args = value.split(":")
+#                module = module_and_args[0]
+#                args = module_and_args[1:]
+#                source_module = __import__(module, {}, {}, [''])
+#                source_instance = source_module.Source(*args)
+#                config['source'] = source_instance
+#            elif var == 'filters':
+#                config['filters'] = []
+#                for module_and_args_str in value.split():
+#                    module_and_args = module_and_args_str.split(":")
+#                    module = module_and_args[0]
+#                    args = module_and_args[1:]
+#                    filter_module = __import__(module, {}, {}, [''])
+#                    filter_instance = filter_module.Filter(*args)
+#                    config['filters'].append(filter_instance)
+#            else:
+#                die("unrecognized paramter in conf file %s: %s\n" % (config_file, var))
 #
-#		if 'domain' not in config or 'source' not in config:
-#			die("must specify domain name and source in conf file %s\n", config_file)
-#		sys.stderr.write("read configuration from %s\n" % config_file)
+#        if 'domain' not in config or 'source' not in config:
+#            die("must specify domain name and source in conf file %s\n", config_file)
+#        sys.stderr.write("read configuration from %s\n" % config_file)
 
 #def reread(signum, frame):
-#	read_config()
-	
+#    read_config()
+
 #def die(msg):
-#	sys.stderr.write(msg)
-#	sys.exit(-1)
+#    sys.stderr.write(msg)
+#    sys.exit(-1)
 
 #def usage(cmd):
-#	die("Usage: %s\n" % (cmd))
+#    die("Usage: %s\n" % (cmd))
 
 #config_files = {}
 #listen_port = 1053
 #listen_host = ''
 
 #try:
-#	options, filenames = getopt.getopt(sys.argv[1:], "p:h:")
+#    options, filenames = getopt.getopt(sys.argv[1:], "p:h:")
 #except getopt.GetoptError:
-#	usage(sys.argv[0])
+#    usage(sys.argv[0])
 
 #for option, value in options:
-#	if option == "-p":
-#		listen_port = int(value)
-#	elif option == "-h":
-#		listen_host = value
+#    if option == "-p":
+#        listen_port = int(value)
+#    elif option == "-h":
+#        listen_host = value
 #if not filenames:
-#	filenames = ['pymds.conf']
+#    filenames = ['pymds.conf']
 #for f in filenames:
-#	if f in config_files:
-#		raise Exception("repeated configuration")
-#	config_files[f] = {}
+#    if f in config_files:
+#        raise Exception("repeated configuration")
+#    config_files[f] = {}
 
 #sys.stdout.write("Starting %s\n" % (sys.argv[0]))
 #read_config()
 #signal.signal(signal.SIGHUP, reread)
 #for config in config_files.values():
-#	sys.stdout.write("%s: serving for domain %s\n" % (sys.argv[0], ".".join(config['domain'])))
+#    sys.stdout.write("%s: serving for domain %s\n" % (sys.argv[0], ".".join(config['domain'])))
 #sys.stdout.flush()
 #sys.stderr.flush()
 #serve()

--- a/lib/dnsServer/listdns.py
+++ b/lib/dnsServer/listdns.py
@@ -3,52 +3,52 @@ import json, base64, types, traceback
 from common import *
 
 def lookup(sp, qdict) :
-	domain = qdict["domain"]
-	if domain.count(".") >= 2 :
-		host = ".".join(domain.split(".")[-2:-1])
-		subdomain = ".".join(domain.split(".")[:-2])
-	else :
-		host = domain.split(".")[0]
-		subdomain = ""
-	#rawlist = json.dumps(rawjson)
-	#error, item = sp.sendJson(['name_show', "d/"+host])
-	item = sp.getData(['data', ['getData', 'd/'+host]])
-	try:
-		item = json.loads(item)
-	except:
-		if app['debug']: traceback.print_exc()
-		return
-	
-	if str(item[u"name"]) == "d/" +  host :
-		try :
-			value = json.loads(item[u"value"])
-			if value.has_key(u"map") :
-				if type(value[u"map"]) is types.DictType :
-					hasdefault = False
-					for key in value[u"map"].keys()[:] :
-						if key == u"" :
-							hasdefault = True
-						if str(key) == subdomain :
-							if type(value[u"map"][key]) == types.DictType :
-								return dnslookup(value, key, qdict)
-							return str(value[u"map"][u""])
-						#else :
-							#if type(value[u"map"][key]) == types.DictType :
-								#return dnslookup(domain, qt)
-							#return 1, str(value[u"map"][key])
-					if hasdefault :
-						if type(value[u"map"][u""]) == types.DictType :
-							return dnslookup(value, u"", qdict)
-						return str(value[u"map"][u""])
-		except :
-			return
-			traceback.print_exc()
+    domain = qdict["domain"]
+    if domain.count(".") >= 2 :
+        host = ".".join(domain.split(".")[-2:-1])
+        subdomain = ".".join(domain.split(".")[:-2])
+    else :
+        host = domain.split(".")[0]
+        subdomain = ""
+    #rawlist = json.dumps(rawjson)
+    #error, item = sp.sendJson(['name_show', "d/"+host])
+    item = sp.getData(['data', ['getData', 'd/'+host]])
+    try:
+        item = json.loads(item)
+    except:
+        if app['debug']: traceback.print_exc()
+        return
+
+    if str(item[u"name"]) == "d/" +  host :
+        try :
+            value = json.loads(item[u"value"])
+            if value.has_key(u"map") :
+                if type(value[u"map"]) is types.DictType :
+                    hasdefault = False
+                    for key in value[u"map"].keys()[:] :
+                        if key == u"" :
+                            hasdefault = True
+                        if str(key) == subdomain :
+                            if type(value[u"map"][key]) == types.DictType :
+                                return dnslookup(value, key, qdict)
+                            return str(value[u"map"][u""])
+                        #else :
+                            #if type(value[u"map"][key]) == types.DictType :
+                                #return dnslookup(domain, qt)
+                            #return 1, str(value[u"map"][key])
+                    if hasdefault :
+                        if type(value[u"map"][u""]) == types.DictType :
+                            return dnslookup(value, u"", qdict)
+                        return str(value[u"map"][u""])
+        except :
+            return
+            traceback.print_exc()
 def dnslookup(value, key, qdict) :
-	if value[u"map"][key].has_key(u"ns") :
-		x = DnsClient.Request(server="8.8.8.8")
-		if type(value[u"map"][key][u"ns"]) == types.UnicodeType :
-			y = x.req(str(value[u"map"][key][u"ns"])).answers[0]["data"]
-		else :
-			y = x.req(str(value[u"map"][key][u"ns"][0])).answers[0]["data"]
-		ns = DNS.Request(server=y)
-		return ns.req(name=qdict["domain"], qtype=qdict["qtype"]).answers[0]
+    if value[u"map"][key].has_key(u"ns") :
+        x = DnsClient.Request(server="8.8.8.8")
+        if type(value[u"map"][key][u"ns"]) == types.UnicodeType :
+            y = x.req(str(value[u"map"][key][u"ns"])).answers[0]["data"]
+        else :
+            y = x.req(str(value[u"map"][key][u"ns"][0])).answers[0]["data"]
+        ns = DNS.Request(server=y)
+        return ns.req(name=qdict["domain"], qtype=qdict["qtype"]).answers[0]

--- a/lib/dnsServer/namecoindns.py
+++ b/lib/dnsServer/namecoindns.py
@@ -9,164 +9,164 @@ from utils import *
 from common import *
 
 class Source(object):
-	#def __init__(self):
-		#self.servers = app['services']['dns'].conf['resolver'].split(',')
-		#self.reqobj = DNS.Request()
-		#jsonfile = open("config.json", "r")
-		#data = json.loads(jsonfile.read())
-		#jsonfile.close()
-		#username = str(data[u"username"])
-		#port = data[u"port"]
-		#password = str(data[u"password"])
-		#self.sp = ServiceProxy("http://%(user)s:%(passwd)s@127.0.0.1:%(port)d" % dict(user=username, passwd=password, port=port))
-		#elf.sp = rpcClient.rpcClientNamecoin('127.0.0.1', port, username, password)
-		#self.sp = app['plugins']['domain']
+    #def __init__(self):
+        #self.servers = app['services']['dns'].conf['resolver'].split(',')
+        #self.reqobj = DNS.Request()
+        #jsonfile = open("config.json", "r")
+        #data = json.loads(jsonfile.read())
+        #jsonfile.close()
+        #username = str(data[u"username"])
+        #port = data[u"port"]
+        #password = str(data[u"password"])
+        #self.sp = ServiceProxy("http://%(user)s:%(passwd)s@127.0.0.1:%(port)d" % dict(user=username, passwd=password, port=port))
+        #elf.sp = rpcClient.rpcClientNamecoin('127.0.0.1', port, username, password)
+        #self.sp = app['plugins']['domain']
 
-#	def _parse_file(self):
-#		f = open(self._filename, "r")
-#		for line in f.readlines():
-#			line = line.strip()		
-#			if line and line[0] != '#':
-#				question, type, value = line.split()
-#				question = question.lower()
-#				type = type.upper()
-#				if question == '@':
-#					question = ''
-#				if type == 'A':
-#					answer = struct.pack("!I", ipstr2int(value))
-#					qtype = 1
-#				if type == 'NS':
-#					answer = labels2str(value.split("."))
-#					qtype = 2
-#				elif type == 'CNAME':
-#					answer = labels2str(value.split("."))
-#					qtype = 5
-#				elif type == 'TXT':
-#					answer = label2str(value)
-#					qtype = 16
-#				elif type == 'MX':
-#					preference, domain = value.split(":")
-#					answer = struct.pack("!H", int(preference))
-#					answer += labels2str(domain.split("."))
-#					qtype = 15
-#				self._answers.setdefault(question, {}).setdefault(qtype, []).append(answer)
-#		f.close()
+#    def _parse_file(self):
+#        f = open(self._filename, "r")
+#        for line in f.readlines():
+#            line = line.strip()
+#            if line and line[0] != '#':
+#                question, type, value = line.split()
+#                question = question.lower()
+#                type = type.upper()
+#                if question == '@':
+#                    question = ''
+#                if type == 'A':
+#                    answer = struct.pack("!I", ipstr2int(value))
+#                    qtype = 1
+#                if type == 'NS':
+#                    answer = labels2str(value.split("."))
+#                    qtype = 2
+#                elif type == 'CNAME':
+#                    answer = labels2str(value.split("."))
+#                    qtype = 5
+#                elif type == 'TXT':
+#                    answer = label2str(value)
+#                    qtype = 16
+#                elif type == 'MX':
+#                    preference, domain = value.split(":")
+#                    answer = struct.pack("!H", int(preference))
+#                    answer += labels2str(domain.split("."))
+#                    qtype = 15
+#                self._answers.setdefault(question, {}).setdefault(qtype, []).append(answer)
+#        f.close()
 
-	def isIP(self, host) :
-		parts = host.split(".")
-		if len(parts) != 4:
-			return False
-		try :
-			valid = False
-			for part in parts :
-				intpart = int(part)
-				if intpart <= 255 and intpart >= 0 :
-					valid = True
-				else : return False
-			if valid :
-				return True
-			return False
-		except : return False
-	def get_response(self, query, domain, qtype, qclass, src_addr):
-		#print query
-		#print domain
-		#print qtype
-		#print qclass
-		#print src_addr
-		if qtype == 1:
-			#answer = struct.pack("!I", ipstr2int(value))
-			reqtype = "A"
-		if qtype == 2:
-			#answer = labels2str(value.split("."))
-			reqtype = "NS"
-		elif qtype == 5:
-			#answer = labels2str(value.split("."))
-			reqtype = "CNAME"
-		elif qtype == 16:
-			#answer = label2str(value)
-			reqtype = "TXT"
-		elif qtype == 15:
-			#preference, domain = value.split(":")
-			#nswer = struct.pack("!H", int(preference))
-			#answer += labels2str(domain.split("."))
-			reqtype = "MX"
-		elif qtype == 28:
-			#answer = struct.pack("!I", ipstr2int(value))
-			reqtype = "AAAA"
-		elif qtype == 52:
-			reqtype = "TLSA"
-		else : reqtype = None
-		answers = app['services']['dns'].lookup({"query":query, "domain":domain, "qtype":qtype, "qclass":qclass, "src_addr":src_addr})
-		#print 'domain:', domain
-		#print 'answers:', answers
-		if domain.endswith(".bit") or domain.endswith(".tor") :
-			#response = listdns.lookup(self.sp, {"query":query, "domain":domain, "qtype":qtype, "qclass":qclass, "src_addr":src_addr})
-			#response = self.sp.lookup({"query":query, "domain":domain, "qtype":qtype, "qclass":qclass, "src_addr":src_addr})
-			response = answers
-			results = []
-			if type(response) == types.DictType :
-				tempresults = {"qtype":response["type"], "qclass":response["class"], "ttl":response["ttl"]}
-				if response["type"] == 1 :
-					#if answers == [] :
-					#	return self.get_response(query, domain, 5, qclass, src_addr)
-					tempresults["rdata"] = struct.pack("!I", ipstr2int(response["data"]))
-				elif response["type"] == 2 or response["type"] == 5:
-					tempresults["rdata"] = labels2str(response["data"].split("."))
-				elif response["type"] == 16 :
-					tempresults["rdata"] = labels2str(response["data"])
-				elif response["type"] == 15 :
-					tempresult = struct.pack("!H", response["data"][0])
-					tempresult += labels2str(response["data"][1].split("."))
-					tempresults["rdata"] = tempresult
-				elif response["type"] == 28 :
-					tempresults["rdata"] = response["data"]
-				elif response["type"] == 52 :
-					tempresult = '\x03\x00'
-					tempresult += chr(int(response["data"][0][0]))
-					tempresult += bytearray.fromhex(response["data"][0][1])
-					tempresults["rdata"] = tempresult
-				#else : return 3, []
-				results.append(tempresults)
-				return 0, results
-			if type(response) == types.StringType :
-				if self.isIP(response) :
-					return 0, [{"qtype":1, "qclass":qclass, "ttl":300, "rdata":struct.pack("!I", ipstr2int(response))}]
-			return 3, []
-			#if query not in self._answers:
-				#return 3, []
-			#if qtype in self._answers[query]:
-			#if domain == "sonicrules.bit":
-			#	results = [{'qtype': 1, 'qclass':qclass, 'ttl': 300, 'rdata': struct.pack("!I", ipstr2int(self.reqobj.req("sonicrules.org", qtype=1).answers[0]["data"]))}]
-			#	return 0, results
-			#elif qtype == 1:
-				# if they asked for an A record and we didn't find one, check for a CNAME
-				#return self.get_response(query, domain, 5, qclass, src_addr)
-		else:
-			#server = self.servers[random.randrange(0, len(self.servers)-1)]
-			#answers = self.reqobj.req(name=domain, qtype=qtype, server=server).answers
-			results = []
-			for response in answers :
-				tempresults = {"qtype":response["type"], "qclass":response["class"], "ttl":response["ttl"]}
-				if response["type"] == 1 :
-					if answers == [] :
-						return self.get_response(query, domain, 5, qclass, src_addr)
-					tempresults["rdata"] = struct.pack("!I", ipstr2int(response["data"]))
-				elif response["type"] == 2 or response["type"] == 5:
-					tempresults["rdata"] = labels2str(response["data"].split("."))
-				elif response["type"] == 16 :
-					tempresults["rdata"] = labels2str(response["data"])
-				elif response["type"] == 15 :
-					tempresult = struct.pack("!H", response["data"][0])
-					tempresult += labels2str(response["data"][1].split("."))
-					tempresults["rdata"] = tempresult
-				elif response["type"] == 28 :
-					if answers == [] :
-						return self.get_response(query, domain, 5, qclass, src_addr)
-					#tempresults["rdata"] = struct.pack("!I", ipstr2int(response["data"]))
-					tempresults["rdata"] = response["data"]
-				elif response["type"] == 52 :
-					tempresults["rdata"] = response["data"]
-				#else : return 3, []
-				results.append(tempresults)
-			return 0, results
-		return 3, []
+    def isIP(self, host) :
+        parts = host.split(".")
+        if len(parts) != 4:
+            return False
+        try :
+            valid = False
+            for part in parts :
+                intpart = int(part)
+                if intpart <= 255 and intpart >= 0 :
+                    valid = True
+                else : return False
+            if valid :
+                return True
+            return False
+        except : return False
+    def get_response(self, query, domain, qtype, qclass, src_addr):
+        #print query
+        #print domain
+        #print qtype
+        #print qclass
+        #print src_addr
+        if qtype == 1:
+            #answer = struct.pack("!I", ipstr2int(value))
+            reqtype = "A"
+        if qtype == 2:
+            #answer = labels2str(value.split("."))
+            reqtype = "NS"
+        elif qtype == 5:
+            #answer = labels2str(value.split("."))
+            reqtype = "CNAME"
+        elif qtype == 16:
+            #answer = label2str(value)
+            reqtype = "TXT"
+        elif qtype == 15:
+            #preference, domain = value.split(":")
+            #nswer = struct.pack("!H", int(preference))
+            #answer += labels2str(domain.split("."))
+            reqtype = "MX"
+        elif qtype == 28:
+            #answer = struct.pack("!I", ipstr2int(value))
+            reqtype = "AAAA"
+        elif qtype == 52:
+            reqtype = "TLSA"
+        else : reqtype = None
+        answers = app['services']['dns'].lookup({"query":query, "domain":domain, "qtype":qtype, "qclass":qclass, "src_addr":src_addr})
+        #print 'domain:', domain
+        #print 'answers:', answers
+        if domain.endswith(".bit") or domain.endswith(".tor") :
+            #response = listdns.lookup(self.sp, {"query":query, "domain":domain, "qtype":qtype, "qclass":qclass, "src_addr":src_addr})
+            #response = self.sp.lookup({"query":query, "domain":domain, "qtype":qtype, "qclass":qclass, "src_addr":src_addr})
+            response = answers
+            results = []
+            if type(response) == types.DictType :
+                tempresults = {"qtype":response["type"], "qclass":response["class"], "ttl":response["ttl"]}
+                if response["type"] == 1 :
+                    #if answers == [] :
+                    #    return self.get_response(query, domain, 5, qclass, src_addr)
+                    tempresults["rdata"] = struct.pack("!I", ipstr2int(response["data"]))
+                elif response["type"] == 2 or response["type"] == 5:
+                    tempresults["rdata"] = labels2str(response["data"].split("."))
+                elif response["type"] == 16 :
+                    tempresults["rdata"] = labels2str(response["data"])
+                elif response["type"] == 15 :
+                    tempresult = struct.pack("!H", response["data"][0])
+                    tempresult += labels2str(response["data"][1].split("."))
+                    tempresults["rdata"] = tempresult
+                elif response["type"] == 28 :
+                    tempresults["rdata"] = response["data"]
+                elif response["type"] == 52 :
+                    tempresult = '\x03\x00'
+                    tempresult += chr(int(response["data"][0][0]))
+                    tempresult += bytearray.fromhex(response["data"][0][1])
+                    tempresults["rdata"] = tempresult
+                #else : return 3, []
+                results.append(tempresults)
+                return 0, results
+            if type(response) == types.StringType :
+                if self.isIP(response) :
+                    return 0, [{"qtype":1, "qclass":qclass, "ttl":300, "rdata":struct.pack("!I", ipstr2int(response))}]
+            return 3, []
+            #if query not in self._answers:
+                #return 3, []
+            #if qtype in self._answers[query]:
+            #if domain == "sonicrules.bit":
+            #    results = [{'qtype': 1, 'qclass':qclass, 'ttl': 300, 'rdata': struct.pack("!I", ipstr2int(self.reqobj.req("sonicrules.org", qtype=1).answers[0]["data"]))}]
+            #    return 0, results
+            #elif qtype == 1:
+                # if they asked for an A record and we didn't find one, check for a CNAME
+                #return self.get_response(query, domain, 5, qclass, src_addr)
+        else:
+            #server = self.servers[random.randrange(0, len(self.servers)-1)]
+            #answers = self.reqobj.req(name=domain, qtype=qtype, server=server).answers
+            results = []
+            for response in answers :
+                tempresults = {"qtype":response["type"], "qclass":response["class"], "ttl":response["ttl"]}
+                if response["type"] == 1 :
+                    if answers == [] :
+                        return self.get_response(query, domain, 5, qclass, src_addr)
+                    tempresults["rdata"] = struct.pack("!I", ipstr2int(response["data"]))
+                elif response["type"] == 2 or response["type"] == 5:
+                    tempresults["rdata"] = labels2str(response["data"].split("."))
+                elif response["type"] == 16 :
+                    tempresults["rdata"] = labels2str(response["data"])
+                elif response["type"] == 15 :
+                    tempresult = struct.pack("!H", response["data"][0])
+                    tempresult += labels2str(response["data"][1].split("."))
+                    tempresults["rdata"] = tempresult
+                elif response["type"] == 28 :
+                    if answers == [] :
+                        return self.get_response(query, domain, 5, qclass, src_addr)
+                    #tempresults["rdata"] = struct.pack("!I", ipstr2int(response["data"]))
+                    tempresults["rdata"] = response["data"]
+                elif response["type"] == 52 :
+                    tempresults["rdata"] = response["data"]
+                #else : return 3, []
+                results.append(tempresults)
+            return 0, results
+        return 3, []

--- a/lib/dnsServer/utils.py
+++ b/lib/dnsServer/utils.py
@@ -5,7 +5,7 @@ def label2str(label):
     s = struct.pack("!B", len(label))
     s += label
     return s
-    
+
 def labels2str(labels):
     s = ''
     for label in labels:

--- a/lib/platformDep.py
+++ b/lib/platformDep.py
@@ -2,9 +2,9 @@ import os
 import platform
 
 def getNamecoinDir():
-	if platform.system() == "Darwin":
-		return os.path.expanduser("~/Library/Application Support/Namecoin/")
-	elif platform.system() == "Windows":
-		return os.path.join(os.environ['APPDATA'], "Namecoin")
-	return os.path.expanduser("~/.namecoin")
+    if platform.system() == "Darwin":
+        return os.path.expanduser("~/Library/Application Support/Namecoin/")
+    elif platform.system() == "Windows":
+        return os.path.join(os.environ['APPDATA'], "Namecoin")
+    return os.path.expanduser("~/.namecoin")
 

--- a/lib/plugin.py
+++ b/lib/plugin.py
@@ -10,194 +10,194 @@ import inspect
 import json
 
 class PluginThread(threading.Thread):
-	daemon = True
-	name = None
-	mode = None
-	desc = None
-	running = False
-	threadRunning = False
-	options = {}
-	helps = {}
-	depends = {}
-	services = {}
-	#version = None
+    daemon = True
+    name = None
+    mode = None
+    desc = None
+    running = False
+    threadRunning = False
+    options = {}
+    helps = {}
+    depends = {}
+    services = {}
+    #version = None
 
-	def __init__(self, mode = 'plugin'):
-		if self.name is None:
-			raise Exception(str(self.__class__) + " : name not defined")
-		self.mode = mode
-		self.nameconf = self.mode + '-' + self.name + '.conf'
-		self.nameclass = self.mode + self.name.capitalize()
-		self.parser = app['parser']
-		self.conf = {}
-		self._loadconfig()
-		threading.Thread.__init__(self)
+    def __init__(self, mode = 'plugin'):
+        if self.name is None:
+            raise Exception(str(self.__class__) + " : name not defined")
+        self.mode = mode
+        self.nameconf = self.mode + '-' + self.name + '.conf'
+        self.nameclass = self.mode + self.name.capitalize()
+        self.parser = app['parser']
+        self.conf = {}
+        self._loadconfig()
+        threading.Thread.__init__(self)
 
-	def start(self):
-		if self.threadRunning: return
-		self.threadRunning = True
-		threading.Thread.start(self)
+    def start(self):
+        if self.threadRunning: return
+        self.threadRunning = True
+        threading.Thread.start(self)
 
-	def run(self):
-		if self.running: return
-		self.start2()
+    def run(self):
+        if self.running: return
+        self.start2()
 
-	def start2(self, arg = []):
-		if app['debug']: print "Plugin %s parent starting" %(self.name)
-		self.running = True
-		# start depends
-		if len(self.depends) > 0:
-			if 'plugins' in self.depends:
-				for dep in self.depends['plugins']:
-					app['plugins'][dep].start()
-			if 'services' in self.depends:
-				for dep in self.depends['services']:
-					app['services'][dep].start()
-		return self.pStart()
+    def start2(self, arg = []):
+        if app['debug']: print "Plugin %s parent starting" %(self.name)
+        self.running = True
+        # start depends
+        if len(self.depends) > 0:
+            if 'plugins' in self.depends:
+                for dep in self.depends['plugins']:
+                    app['plugins'][dep].start()
+            if 'services' in self.depends:
+                for dep in self.depends['services']:
+                    app['services'][dep].start()
+        return self.pStart()
 
-	def pStart(self, arg = []):
-		if app['debug']: print "Plugin %s parent start" %(self.name)
-		#time.sleep(1)
-		return True
+    def pStart(self, arg = []):
+        if app['debug']: print "Plugin %s parent start" %(self.name)
+        #time.sleep(1)
+        return True
 
-	def stop(self, arg = []):
-		if not self.running: return
-		if app['debug']: print "Plugin %s parent stopping" %(self.name)
-		self.running = False
-		return self.pStop()
+    def stop(self, arg = []):
+        if not self.running: return
+        if app['debug']: print "Plugin %s parent stopping" %(self.name)
+        self.running = False
+        return self.pStop()
 
-	def pStop(self, arg = []):
-		if app['debug']: print "Plugin %s parent stop" %(self.name)
-		print "Plugin %s stopped" %(self.name)
-		return True
+    def pStop(self, arg = []):
+        if app['debug']: print "Plugin %s parent stop" %(self.name)
+        print "Plugin %s stopped" %(self.name)
+        return True
 
-	def status(self, arg = []):
-		return self.pStatus()
+    def status(self, arg = []):
+        return self.pStatus()
 
-	def pStatus(self, arg = []):
-		if self.running:
-			return "Plugin " + self.name + " running"
+    def pStatus(self, arg = []):
+        if self.running:
+            return "Plugin " + self.name + " running"
 
-	def reload(self, arg = []):
-		if app['debug']: print "Plugin %s parent reloading" %(self.name)
-		return self.pReload()
-	
-	def pReload(self, arg = []):
-		if app['debug']: print "Plugin %s parent reload" %(self.name)
-		self.loadconfig()
-		return True
+    def reload(self, arg = []):
+        if app['debug']: print "Plugin %s parent reloading" %(self.name)
+        return self.pReload()
 
-	def restart(self, arg = []):
-		if app['debug']: print "Plugin %s parent restarting" %(self.name)
-		return self.pRestart()
+    def pReload(self, arg = []):
+        if app['debug']: print "Plugin %s parent reload" %(self.name)
+        self.loadconfig()
+        return True
 
-	def pRestart(self, arg = []):
-		if app['debug']: print "Plugin %s parent restart" %(self.name)
-		self.stop()
-		self.start2()
-		return True
+    def restart(self, arg = []):
+        if app['debug']: print "Plugin %s parent restarting" %(self.name)
+        return self.pRestart()
 
-	def help(self, *arg):
-		return self.pHelp(*arg)
+    def pRestart(self, arg = []):
+        if app['debug']: print "Plugin %s parent restart" %(self.name)
+        self.stop()
+        self.start2()
+        return True
 
-	def pHelp(self, *args):
-		if len(args) > 0 and type(args[0]) != list:
-			method = args[0]
-			if method in self.helps:
-				help = self.helps[method][3]
-				help += '\n' + method + ' ' + self.helps[method][2]
-				return help
+    def help(self, *arg):
+        return self.pHelp(*arg)
 
-		methods = self._getPluginMethods()
-		help = '* Available commands for plugin ' + self.name + ' :'
-		for method in methods:
-			if method in self.helps:
-				method = method + ' ' + self.helps[method][2]
-			help += '\n' + method
-		return help
+    def pHelp(self, *args):
+        if len(args) > 0 and type(args[0]) != list:
+            method = args[0]
+            if method in self.helps:
+                help = self.helps[method][3]
+                help += '\n' + method + ' ' + self.helps[method][2]
+                return help
 
-	def _getPluginMethods(self):
-		parents = []
-		parentmethods = inspect.getmembers(threading.Thread)
-		for (method, value) in parentmethods:
-			parents.append(method)
+        methods = self._getPluginMethods()
+        help = '* Available commands for plugin ' + self.name + ' :'
+        for method in methods:
+            if method in self.helps:
+                method = method + ' ' + self.helps[method][2]
+            help += '\n' + method
+        return help
 
-		methods = []
-		allmethods = inspect.getmembers(self, predicate=inspect.ismethod)
-		for (method, value) in allmethods:
-			if method[0] == '_':
-				continue
-			if method[0] == 'p' and method[1].upper() == method[1]:
-				continue
-			if method in parents:
-				continue
-			if method == 'start2': method = 'start'
-			if method in self.helps:
-				method = method + ' ' + self.helps[method][2]
-			methods.append(method)
-		methods.sort()
-		return methods
+    def _getPluginMethods(self):
+        parents = []
+        parentmethods = inspect.getmembers(threading.Thread)
+        for (method, value) in parentmethods:
+            parents.append(method)
 
-	def _loadconfig(self, arg = []):
-		# manage services
-		for service, value in self.services.iteritems():
-			if self.name not in app['services'][service].services:
-				app['services'][service].services = {}
-			app['services'][service].services[self.name] = value
+        methods = []
+        allmethods = inspect.getmembers(self, predicate=inspect.ismethod)
+        for (method, value) in allmethods:
+            if method[0] == '_':
+                continue
+            if method[0] == 'p' and method[1].upper() == method[1]:
+                continue
+            if method in parents:
+                continue
+            if method == 'start2': method = 'start'
+            if method in self.helps:
+                method = method + ' ' + self.helps[method][2]
+            methods.append(method)
+        methods.sort()
+        return methods
 
-		# add command line args to the program options + build default configuration data
-		defaultConf = '[' + self.name + ']\n'
-		group = OptionGroup(app['parser'], self.name.capitalize() + " Options", self.desc)
-		if self.options.__class__ is dict:	
-			tmp = []
-			for option, value in self.options.items():
-				tmp.append({option: value})
-			self.options = tmp
-		#for option, value in self.options.items():
-		for option in self.options:
-			option, value = option.items()[0]
-			if len(value) == 3:
-				help = value[0] + " " + value[2] + ""
-				defaultConf += '; ' + value[0] + ' - choices: ' + value[2] + '\n'
-			else:
-				help = value[0]
-				defaultConf += '; ' + value[0] + '\n'
-			defaultConf += ';' + option + '=' + str(value[1]) + '\n\n'
-			if option != 'start':
-				if self.name == 'main':
-					group.add_option('--' + option, '--' + self.name + '.' + option, type='str', help=help, metavar=str(value[1]))
-				else:
-					group.add_option('--' + self.name + '.' + option, type='str', help=help, metavar=str(value[1]))
-			self.conf[option] = value[1]
-		app['parser'].add_option_group(group)
+    def _loadconfig(self, arg = []):
+        # manage services
+        for service, value in self.services.iteritems():
+            if self.name not in app['services'][service].services:
+                app['services'][service].services = {}
+            app['services'][service].services[self.name] = value
 
-		# create default config if none
-		userConfFile = app['path']['conf'] + self.nameconf
-		if not os.path.exists(userConfFile):
-			if not os.path.exists(app['path']['conf']):
-				os.mkdir(app['path']['conf'])
-			fp = open(userConfFile, 'w')
-			fp.write(defaultConf)
-			fp.close()
+        # add command line args to the program options + build default configuration data
+        defaultConf = '[' + self.name + ']\n'
+        group = OptionGroup(app['parser'], self.name.capitalize() + " Options", self.desc)
+        if self.options.__class__ is dict:
+            tmp = []
+            for option, value in self.options.items():
+                tmp.append({option: value})
+            self.options = tmp
+        #for option, value in self.options.items():
+        for option in self.options:
+            option, value = option.items()[0]
+            if len(value) == 3:
+                help = value[0] + " " + value[2] + ""
+                defaultConf += '; ' + value[0] + ' - choices: ' + value[2] + '\n'
+            else:
+                help = value[0]
+                defaultConf += '; ' + value[0] + '\n'
+            defaultConf += ';' + option + '=' + str(value[1]) + '\n\n'
+            if option != 'start':
+                if self.name == 'main':
+                    group.add_option('--' + option, '--' + self.name + '.' + option, type='str', help=help, metavar=str(value[1]))
+                else:
+                    group.add_option('--' + self.name + '.' + option, type='str', help=help, metavar=str(value[1]))
+            self.conf[option] = value[1]
+        app['parser'].add_option_group(group)
 
-		# read user config
-		fileconf = SafeConfigParser()
-		fileconf.read(userConfFile)
+        # create default config if none
+        userConfFile = app['path']['conf'] + self.nameconf
+        if not os.path.exists(userConfFile):
+            if not os.path.exists(app['path']['conf']):
+                os.mkdir(app['path']['conf'])
+            fp = open(userConfFile, 'w')
+            fp.write(defaultConf)
+            fp.close()
 
-		# set user config
-		for option in fileconf.options(self.name):
-			self.conf[option] = fileconf.get(self.name, option)
+        # read user config
+        fileconf = SafeConfigParser()
+        fileconf.read(userConfFile)
 
-		self.pLoadconfig()
+        # set user config
+        for option in fileconf.options(self.name):
+            self.conf[option] = fileconf.get(self.name, option)
 
-	def pLoadconfig(self, arg = []):
-		pass
+        self.pLoadconfig()
 
-	# call a plugin method
-	def _rpc(self, method, *args): #, module = None):
-		#if module is not None and (type(module) == str or type(module) == unicode):
-		#	self = __import__(module)
-		#elif module is not None:
-		#	self = module
-		func = getattr(self, method)
-		return func(*args)
+    def pLoadconfig(self, arg = []):
+        pass
+
+    # call a plugin method
+    def _rpc(self, method, *args): #, module = None):
+        #if module is not None and (type(module) == str or type(module) == unicode):
+        #    self = __import__(module)
+        #elif module is not None:
+        #    self = module
+        func = getattr(self, method)
+        return func(*args)

--- a/lib/rpcClient.py
+++ b/lib/rpcClient.py
@@ -4,120 +4,120 @@ import base64
 import time
 
 class rpcClient:
-	s = None
-	size = 4096
-	conf = {}
+    s = None
+    size = 4096
+    conf = {}
 
-	def __init__(self, host, port, user = None, password = None, timeout = 5):
-		self.conf['host'] = host
-		self.conf['port'] = port
-		if user is not None:
-			self.conf['user'] = user
-		if password is not None:
-			self.conf['password'] = password
-		if timeout is not None:
-			self.conf['timeout'] = timeout
+    def __init__(self, host, port, user = None, password = None, timeout = 5):
+        self.conf['host'] = host
+        self.conf['port'] = port
+        if user is not None:
+            self.conf['user'] = user
+        if password is not None:
+            self.conf['password'] = password
+        if timeout is not None:
+            self.conf['timeout'] = timeout
 
-	def send(self, data):
-		start = time.time()
-		try:
-			self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-			self.s.settimeout(self.conf['timeout'])
-			self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-			self.s.connect((self.conf['host'], int(self.conf['port'])))
-			#print '* Sending :', '\n', data
-			self.s.sendall(data)
-			result = ''.decode('iso-8859-1')
-			while True:
-				try:
-					tmp = self.s.recv(self.size).decode('iso-8859-1')
-				except socket.timeout as e:
-					break
-				self.s.settimeout(time.time() - start + 2)
-				if not tmp: break
-				result += tmp
-				if len(tmp)%self.size != 0: break
+    def send(self, data):
+        start = time.time()
+        try:
+            self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.s.settimeout(self.conf['timeout'])
+            self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.s.connect((self.conf['host'], int(self.conf['port'])))
+            #print '* Sending :', '\n', data
+            self.s.sendall(data)
+            result = ''.decode('iso-8859-1')
+            while True:
+                try:
+                    tmp = self.s.recv(self.size).decode('iso-8859-1')
+                except socket.timeout as e:
+                    break
+                self.s.settimeout(time.time() - start + 2)
+                if not tmp: break
+                result += tmp
+                if len(tmp)%self.size != 0: break
 
-			#print '* Received :', '\n', result
-			self.s.close()
-			return (None, result)
+            #print '* Received :', '\n', result
+            self.s.close()
+            return (None, result)
 
-		except socket.error as e:
-			return (True, str(e) + ' - Unable to send command : ' + str(data))
-		except Exception as e:
-			return (True, 'Exception : ' + str(e))
+        except socket.error as e:
+            return (True, str(e) + ' - Unable to send command : ' + str(data))
+        except Exception as e:
+            return (True, 'Exception : ' + str(e))
 
-	def sendJson(self, params):
-		method = params[0]
-		params.remove(method)
-		body = json.dumps({'method': method, 'params': params, 'id':1})
+    def sendJson(self, params):
+        method = params[0]
+        params.remove(method)
+        body = json.dumps({'method': method, 'params': params, 'id':1})
 
-		(error, result) = self.send(body)
+        (error, result) = self.send(body)
 
-		try:
-			result2 = json.loads(result)
+        try:
+            result2 = json.loads(result)
 
-			return (error, result2)
-		except Exception as e:
-			if error and 'Connection refused' in result:
-				return (True, "Can't contact server - command " + method)
+            return (error, result2)
+        except Exception as e:
+            if error and 'Connection refused' in result:
+                return (True, "Can't contact server - command " + method)
 
-			return (True, result)
+            return (True, result)
 
 
 class rpcClientNamecoin(rpcClient):
-	def __init__(self, host, port, user = None, password = None, timeout = 60):
-		rpcClient.__init__(self, host, port, user, password, timeout)
+    def __init__(self, host, port, user = None, password = None, timeout = 60):
+        rpcClient.__init__(self, host, port, user, password, timeout)
 
-	def sendJson(self, params):
-		method = params[0]
-		params.remove(method)
-		body = json.dumps({'method': method, 'params': params, 'id':1})
+    def sendJson(self, params):
+        method = params[0]
+        params.remove(method)
+        body = json.dumps({'method': method, 'params': params, 'id':1})
 
-		header  = 'POST / HTTP/1.1\n'
-		header += 'User-Agent: bitcoin-json-rpc/0.3.50' + '\n'
-		header += 'Host: 127.0.0.1\n'
-		header += 'Content-Type: application/json' + '\n'
-		header += 'Content-Length: ' + str(len(body)) + '\n'
-		header += 'Accept: application/json' + '\n'
-		if  self.conf['user'] is not None and self.conf['password'] is not None:
-			header += 'Authorization: Basic ' + base64.b64encode(self.conf['user'] + ':' + self.conf['password'], None) + '\n'
-		
-		(error, data) = self.send(header + '\n' + body)
+        header  = 'POST / HTTP/1.1\n'
+        header += 'User-Agent: bitcoin-json-rpc/0.3.50' + '\n'
+        header += 'Host: 127.0.0.1\n'
+        header += 'Content-Type: application/json' + '\n'
+        header += 'Content-Length: ' + str(len(body)) + '\n'
+        header += 'Accept: application/json' + '\n'
+        if  self.conf['user'] is not None and self.conf['password'] is not None:
+            header += 'Authorization: Basic ' + base64.b64encode(self.conf['user'] + ':' + self.conf['password'], None) + '\n'
 
-		resp = None
-		found = False
-		data = data.split('\r\n')
-		for line in data:
-			if line == '':
-				found = True
-			elif found:
-				resp = line
+        (error, data) = self.send(header + '\n' + body)
 
-		try:
-			resp = json.loads(resp)
-			if resp is None or 'error' in resp and resp['error'] is not None:
-				return (True, None)
-			else:
-				return (None, resp['result'])
-		except Exception as e:
-			return (True, e)
+        resp = None
+        found = False
+        data = data.split('\r\n')
+        for line in data:
+            if line == '':
+                found = True
+            elif found:
+                resp = line
+
+        try:
+            resp = json.loads(resp)
+            if resp is None or 'error' in resp and resp['error'] is not None:
+                return (True, None)
+            else:
+                return (None, resp['result'])
+        except Exception as e:
+            return (True, e)
 
 
 if __name__=='__main__':
-	r = rpcClientNamecoin('127.0.0.1', 8337, 'namecoin', 'test165893741', 30)
-	print "Sending", ['getinfo']
-	print r.sendJson(['getinfo']), '\n'
-	print "Sending", ['name_show','d/ns']
-	print r.sendJson(['name_show','d/ns']), '\n'
+    r = rpcClientNamecoin('127.0.0.1', 8337, 'namecoin', 'test165893741', 30)
+    print "Sending", ['getinfo']
+    print r.sendJson(['getinfo']), '\n'
+    print "Sending", ['name_show','d/ns']
+    print r.sendJson(['name_show','d/ns']), '\n'
 
-	r = rpcClient('127.0.0.1', 9000)
-	print "Sending", 'test'
-	print r.send('test'), '\n'
+    r = rpcClient('127.0.0.1', 9000)
+    print "Sending", 'test'
+    print r.send('test'), '\n'
 
-	r = rpcClient('127.0.0.1', 9000)
-	print "Sending", ['main', 'status']
-	print r.sendJson(['main', 'status']), '\n'
-	print "Sending", ['status']
-	print r.sendJson(['status']), '\n'
+    r = rpcClient('127.0.0.1', 9000)
+    print "Sending", ['main', 'status']
+    print r.sendJson(['main', 'status']), '\n'
+    print "Sending", ['status']
+    print r.sendJson(['status']), '\n'
 

--- a/nmcontrol.py
+++ b/nmcontrol.py
@@ -10,120 +10,120 @@ import ConfigParser
 
 app = {}
 def main():
-	# init app config
-	global app
-	app['conf'] = ConfigParser.SafeConfigParser()
-	app['path'] = {}
-	app['path']['app'] = os.path.dirname(os.path.realpath(__file__)) + os.sep
-	app['path']['conf'] = app['path']['app'] + os.sep + 'conf' + os.sep
+    # init app config
+    global app
+    app['conf'] = ConfigParser.SafeConfigParser()
+    app['path'] = {}
+    app['path']['app'] = os.path.dirname(os.path.realpath(__file__)) + os.sep
+    app['path']['conf'] = app['path']['app'] + os.sep + 'conf' + os.sep
 
-	# add import path
-	sys.path.append(app['path']['app'] + 'lib')
-	sys.path.append(app['path']['app'] + 'plugin')
-	sys.path.append(app['path']['app'] + 'service')
+    # add import path
+    sys.path.append(app['path']['app'] + 'lib')
+    sys.path.append(app['path']['app'] + 'plugin')
+    sys.path.append(app['path']['app'] + 'service')
 
-	import common
-	common.app = app
+    import common
+    common.app = app
 
-	import console
-	(cWidth, cHeight) = console.getTerminalSize()
-	fmt=optparse.IndentedHelpFormatter(indent_increment=4, max_help_position=40, width=cWidth-3, short_first=1 )
-	app['parser'] = optparse.OptionParser(formatter=fmt,description='nmcontrol %s' % __version__)
-	app['debug'] = False
+    import console
+    (cWidth, cHeight) = console.getTerminalSize()
+    fmt=optparse.IndentedHelpFormatter(indent_increment=4, max_help_position=40, width=cWidth-3, short_first=1 )
+    app['parser'] = optparse.OptionParser(formatter=fmt,description='nmcontrol %s' % __version__)
+    app['debug'] = False
 
-	# debug mode
-	for argv in sys.argv:
-		if argv in ['--debug=1','--main.debug=1']:
-			app['debug'] = True
+    # debug mode
+    for argv in sys.argv:
+        if argv in ['--debug=1','--main.debug=1']:
+            app['debug'] = True
 
-	# init modules
-	import re
-	import dircache
+    # init modules
+    import re
+    import dircache
 
-	# init vars and main plugin
-	app['services'] = {}
-	app['plugins'] = {}
-	import pluginMain
-	app['plugins']['main'] = pluginMain.pluginMain('plugin')
+    # init vars and main plugin
+    app['services'] = {}
+    app['plugins'] = {}
+    import pluginMain
+    app['plugins']['main'] = pluginMain.pluginMain('plugin')
 
-	# init service & plugins
-	for modType in ['service', 'plugin']:
-		modules = dircache.listdir(modType)
-		if modType == 'plugin': modules.remove('pluginMain.py')
-		for module in modules:
-			if re.match("^"+modType+".*.py$", module):
-				module = re.sub(r'\.py$', '', module)
-				modulename = re.sub(r'^'+modType, '', module).lower()
-				try:
-					importedModule = __import__(module)
-					importedClass = getattr(importedModule, module)
-					app[modType+'s'][importedClass.name] = importedClass(modType)
-					importedClass.app = app
-				except Exception as e:
-					print "Exception when loading "+modType, module, ":", e
+    # init service & plugins
+    for modType in ['service', 'plugin']:
+        modules = dircache.listdir(modType)
+        if modType == 'plugin': modules.remove('pluginMain.py')
+        for module in modules:
+            if re.match("^"+modType+".*.py$", module):
+                module = re.sub(r'\.py$', '', module)
+                modulename = re.sub(r'^'+modType, '', module).lower()
+                try:
+                    importedModule = __import__(module)
+                    importedClass = getattr(importedModule, module)
+                    app[modType+'s'][importedClass.name] = importedClass(modType)
+                    importedClass.app = app
+                except Exception as e:
+                    print "Exception when loading "+modType, module, ":", e
 
-	# parse command line options
-	(options, app['args']) = app['parser'].parse_args()
-	if app['debug']: print "Cmdline args:", app['args']
-	if app['debug']: print "Cmdline options:", options
-	for option, value in vars(options).items():
-		if value is not None:
-			tmp = option.split('.')
-			if len(tmp) == 1:
-				app['plugins']['main'].conf[tmp[0]] = value
-			else:
-				module = tmp[0]
-				tmp.remove(module)
-				if module in app['plugins']:
-					app['plugins'][module].conf['.'.join(tmp)] = value
-				elif module in app['services']:
-					app['services'][module].conf['.'.join(tmp)] = value
+    # parse command line options
+    (options, app['args']) = app['parser'].parse_args()
+    if app['debug']: print "Cmdline args:", app['args']
+    if app['debug']: print "Cmdline options:", options
+    for option, value in vars(options).items():
+        if value is not None:
+            tmp = option.split('.')
+            if len(tmp) == 1:
+                app['plugins']['main'].conf[tmp[0]] = value
+            else:
+                module = tmp[0]
+                tmp.remove(module)
+                if module in app['plugins']:
+                    app['plugins'][module].conf['.'.join(tmp)] = value
+                elif module in app['services']:
+                    app['services'][module].conf['.'.join(tmp)] = value
 
-	###### Act as client : send rpc request ######
-	if len(app['args']) > 0 and app['args'][0] != 'start':
-		error, data = app['plugins']['rpc'].pSend(app['args'][:])
-		if error is True or data['error'] is True:
-			print "ERROR:", data
-		else:
-			if data['result']['reply'] in [None, True]:
-				print 'ok'
-			else:
-				print data['result']['reply']
-			if app['debug'] and data['result']['prints']: print "LOG:", data['result']['prints']
-		if app['args'][0] != 'restart':
-			return
+    ###### Act as client : send rpc request ######
+    if len(app['args']) > 0 and app['args'][0] != 'start':
+        error, data = app['plugins']['rpc'].pSend(app['args'][:])
+        if error is True or data['error'] is True:
+            print "ERROR:", data
+        else:
+            if data['result']['reply'] in [None, True]:
+                print 'ok'
+            else:
+                print data['result']['reply']
+            if app['debug'] and data['result']['prints']: print "LOG:", data['result']['prints']
+        if app['args'][0] != 'restart':
+            return
 
-	# daemon mode
-	if int(app['plugins']['main'].conf['daemon']) == 1:
-		print "Entering background mode"
-		import daemonize
-		retCode = daemonize.createDaemon()
+    # daemon mode
+    if int(app['plugins']['main'].conf['daemon']) == 1:
+        print "Entering background mode"
+        import daemonize
+        retCode = daemonize.createDaemon()
 
-	###### Act as server : start plugins ######
-	plugins_started = []
-	for plugin in app['plugins']:
-		if int(app['plugins'][plugin].conf['start']) == 1 and plugin not in ['rpc','main']:
-			# exit immediatly when main is stopped, unless in debug mode
-			app['plugins'][plugin].daemon=True
-			if app['plugins'][plugin].running is False:
-				app['plugins'][plugin].start()
-				plugins_started.append(app['plugins'][plugin].name)
-	print "Plugins started :", ', '.join(plugins_started)
+    ###### Act as server : start plugins ######
+    plugins_started = []
+    for plugin in app['plugins']:
+        if int(app['plugins'][plugin].conf['start']) == 1 and plugin not in ['rpc','main']:
+            # exit immediatly when main is stopped, unless in debug mode
+            app['plugins'][plugin].daemon=True
+            if app['plugins'][plugin].running is False:
+                app['plugins'][plugin].start()
+                plugins_started.append(app['plugins'][plugin].name)
+    print "Plugins started :", ', '.join(plugins_started)
 
-	#services_started = []
-	#for service in app['services']:
-	#	if app['services'][service].running:
-	#		services_started.append(app['services'][service].name)
-	#print "Services started :", ', '.join(services_started)
+    #services_started = []
+    #for service in app['services']:
+    #    if app['services'][service].running:
+    #        services_started.append(app['services'][service].name)
+    #print "Services started :", ', '.join(services_started)
 
-	# stay there to catch CTRL + C and not exit when in daemon mode
-	try:
-		app['plugins']['main'].start2()
-	except (KeyboardInterrupt, SystemExit):
-		print '\n! Received keyboard interrupt, quitting threads.\n'
+    # stay there to catch CTRL + C and not exit when in daemon mode
+    try:
+        app['plugins']['main'].start2()
+    except (KeyboardInterrupt, SystemExit):
+        print '\n! Received keyboard interrupt, quitting threads.\n'
 
-	# stop main program
-	app['plugins']['main'].stop()
+    # stop main program
+    app['plugins']['main'].stop()
 
 
 if __name__=='__main__':

--- a/plugin/pluginData.py
+++ b/plugin/pluginData.py
@@ -7,196 +7,196 @@ import backendDataFile
 import backendDataNamecoin
 
 class pluginData(plugin.PluginThread):
-	name = 'data'
-	options = [
-		{'start':			['launch at startup', 1]},
-		{'import.mode':		['Import data at launch', 'none', '<none|all>']},
-		{'import.from':		['Import data from', 'namecoin', '<namecoin|file>']},
-		{'import.file':		['Import data from file ', 'data' + os.sep + 'namecoin.dat']},
-		{'import.namecoin':	['Path of namecoin.conf', platformDep.getNamecoinDir() + os.sep + 'namecoin.conf']},
+    name = 'data'
+    options = [
+        {'start':            ['launch at startup', 1]},
+        {'import.mode':        ['Import data at launch', 'none', '<none|all>']},
+        {'import.from':        ['Import data from', 'namecoin', '<namecoin|file>']},
+        {'import.file':        ['Import data from file ', 'data' + os.sep + 'namecoin.dat']},
+        {'import.namecoin':    ['Path of namecoin.conf', platformDep.getNamecoinDir() + os.sep + 'namecoin.conf']},
 
-		{'update.mode':		['Update mode', 'ondemand', '<none|all|ondemand>']},
-		{'update.from':		['Update data from', 'namecoin', '<namecoin|url|file>']},
-		{'update.freq':		['Update data if older than', '30m', '<number>[h|m|s]']},
-		{'update.file':		['Update data from file ', 'data' + os.sep + 'namecoin.dat']},
-		{'update.namecoin':	['Path of namecoin.conf', platformDep.getNamecoinDir() + os.sep + 'namecoin.conf']},
+        {'update.mode':        ['Update mode', 'ondemand', '<none|all|ondemand>']},
+        {'update.from':        ['Update data from', 'namecoin', '<namecoin|url|file>']},
+        {'update.freq':        ['Update data if older than', '30m', '<number>[h|m|s]']},
+        {'update.file':        ['Update data from file ', 'data' + os.sep + 'namecoin.dat']},
+        {'update.namecoin':    ['Path of namecoin.conf', platformDep.getNamecoinDir() + os.sep + 'namecoin.conf']},
 
-		{'export.mode':		['Export mode', 'none', '<none|all>']},
-		{'export.to':		['Export data to', 'file']},
-		{'export.freq':		['Export data frequency', '1h', '<number>[h|m|s]']},
-		{'export.file':		['Export data to file ', 'data' + os.sep + 'namecoin.dat']},
-	]
-	helps = {
-		'getData':	[1, 1, '<name>', 'Get raw data of a name'],
-		'getValue':	[1, 1, '<name>', 'Get raw value of a name'],
-		'getValueProcessed':
-				[1, 1, '<name>', 'Get JSON value with imports processed'],
-		'getJson':	[1, 1, '<name> <key1,key2,key3,...>', 'Get the json record for specified keys'],
-	}
+        {'export.mode':        ['Export mode', 'none', '<none|all>']},
+        {'export.to':        ['Export data to', 'file']},
+        {'export.freq':        ['Export data frequency', '1h', '<number>[h|m|s]']},
+        {'export.file':        ['Export data to file ', 'data' + os.sep + 'namecoin.dat']},
+    ]
+    helps = {
+        'getData':    [1, 1, '<name>', 'Get raw data of a name'],
+        'getValue':    [1, 1, '<name>', 'Get raw value of a name'],
+        'getValueProcessed':
+                [1, 1, '<name>', 'Get JSON value with imports processed'],
+        'getJson':    [1, 1, '<name> <key1,key2,key3,...>', 'Get the json record for specified keys'],
+    }
 
-	# Maximum recursion depth for processing "import" keys.
-	maxNestedCalls = 10
+    # Maximum recursion depth for processing "import" keys.
+    maxNestedCalls = 10
 
-	data = {}
-	update = None
-	export = None
+    data = {}
+    update = None
+    export = None
 
-	def pLoadconfig(self):
-		# convert string interval to a number of seconds
-		for key, value in self.conf.items():
-			if '.freq' in key:
-				if value[-1] == 's':
-					self.conf[key] = int(value[0:-1])
-				elif value[-1] == 'm':
-					self.conf[key] = int(value[0:-1]) * 60
-				elif value[-1] == 'h':
-					self.conf[key] = int(value[0:-1]) * 60 * 60
-				else:
-					self.conf[key] = int(value)
+    def pLoadconfig(self):
+        # convert string interval to a number of seconds
+        for key, value in self.conf.items():
+            if '.freq' in key:
+                if value[-1] == 's':
+                    self.conf[key] = int(value[0:-1])
+                elif value[-1] == 'm':
+                    self.conf[key] = int(value[0:-1]) * 60
+                elif value[-1] == 'h':
+                    self.conf[key] = int(value[0:-1]) * 60 * 60
+                else:
+                    self.conf[key] = int(value)
 
-	def pStatus(self):
-		if self.running:
-			return "Plugin " + self.name + " running (" + str(len(self.data)) + " names)"
+    def pStatus(self):
+        if self.running:
+            return "Plugin " + self.name + " running (" + str(len(self.data)) + " names)"
 
-	def pStart(self):
-		# build filter for namespaces
-		namespaces = []
-		self.conf['name_filter'] = ''
-		for plugin in app['plugins']:
-			if app['plugins'][plugin].conf['start'] == 1:
-				if hasattr(app['plugins'][plugin], 'namespaces'):
-					namespaces.extend(app['plugins'][plugin].namespaces)
-		if len(namespaces) > 0:
-			self.conf['name_filter'] = '^' + '|'.join(namespaces) + '/'
+    def pStart(self):
+        # build filter for namespaces
+        namespaces = []
+        self.conf['name_filter'] = ''
+        for plugin in app['plugins']:
+            if app['plugins'][plugin].conf['start'] == 1:
+                if hasattr(app['plugins'][plugin], 'namespaces'):
+                    namespaces.extend(app['plugins'][plugin].namespaces)
+        if len(namespaces) > 0:
+            self.conf['name_filter'] = '^' + '|'.join(namespaces) + '/'
 
-		# load import backend
-		if self.conf['import.mode'] == 'all':
-			if app['debug']: print "Plugin Data : loading...",
-			sys.stdout.flush()
-			importedModule = __import__('backendData' + self.conf['import.from'].capitalize())
-			importedClass = getattr(importedModule, 'backendData')
-			backend = importedClass(self.conf['import.' + self.conf['import.from']])
-			error, data = backend.getAllNames()
-			if error is None:
-				self.data = data
-			# set expire time if not set
-			for name in self.data:
-				if 'expires_at' not in self.data[name]:
-					self.data[name]['expires_at'] = int(time.time() + self.conf['update.freq'])
-			if app['debug']: print len(self.data), "names loaded"
+        # load import backend
+        if self.conf['import.mode'] == 'all':
+            if app['debug']: print "Plugin Data : loading...",
+            sys.stdout.flush()
+            importedModule = __import__('backendData' + self.conf['import.from'].capitalize())
+            importedClass = getattr(importedModule, 'backendData')
+            backend = importedClass(self.conf['import.' + self.conf['import.from']])
+            error, data = backend.getAllNames()
+            if error is None:
+                self.data = data
+            # set expire time if not set
+            for name in self.data:
+                if 'expires_at' not in self.data[name]:
+                    self.data[name]['expires_at'] = int(time.time() + self.conf['update.freq'])
+            if app['debug']: print len(self.data), "names loaded"
 
-		# load update backend
-		if self.conf['update.mode'] != 'none':
-			importedModule = __import__('backendData' + self.conf['update.from'].capitalize())
-			importedClass = getattr(importedModule, 'backendData')
-			self.update = importedClass(self.conf['update.' + self.conf['update.from']])
+        # load update backend
+        if self.conf['update.mode'] != 'none':
+            importedModule = __import__('backendData' + self.conf['update.from'].capitalize())
+            importedClass = getattr(importedModule, 'backendData')
+            self.update = importedClass(self.conf['update.' + self.conf['update.from']])
 
-		# load export backend
-		if self.conf['export.mode'] != 'none':
-			importedModule = __import__('backendData' + self.conf['export.to'].capitalize())
-			importedClass = getattr(importedModule, 'backendData')
-			self.export = importedClass(self.conf['export.' + self.conf['export.to']])
+        # load export backend
+        if self.conf['export.mode'] != 'none':
+            importedModule = __import__('backendData' + self.conf['export.to'].capitalize())
+            importedClass = getattr(importedModule, 'backendData')
+            self.export = importedClass(self.conf['export.' + self.conf['export.to']])
 
-	def getData(self, name):
-		if name not in self.data or self.data[name]['expires_at'] < time.time():
-			error, data = self.update.getName(name)
-			if error is None:
-				
-				if 'expired' in data and data['expired']:
-					if app['debug']:
-						print name, 'is expired in the blockchain.'
-					return False
-				
-				data['expires_at'] = int(time.time() + self.conf['update.freq'])
-				self.data[name] = data
+    def getData(self, name):
+        if name not in self.data or self.data[name]['expires_at'] < time.time():
+            error, data = self.update.getName(name)
+            if error is None:
 
-		if name in self.data:
-			return json.dumps(self.data[name])
-		else:
-			return False
+                if 'expired' in data and data['expired']:
+                    if app['debug']:
+                        print name, 'is expired in the blockchain.'
+                    return False
 
-	def getValue(self, name):
-		data = self.getData(name)
+                data['expires_at'] = int(time.time() + self.conf['update.freq'])
+                self.data[name] = data
 
-		if not data:
-			return False
+        if name in self.data:
+            return json.dumps(self.data[name])
+        else:
+            return False
 
-		data = json.loads(data)
-		if 'value' in data:
-			return data['value']
+    def getValue(self, name):
+        data = self.getData(name)
 
-		return False
+        if not data:
+            return False
 
-	def getValueProcessed(self, name):
-		data = self.getValue(name)
-		try:	
-			data = json.loads(data)
-		except:
-			if app['debug']: traceback.print_exc()
-			return False
+        data = json.loads(data)
+        if 'value' in data:
+            return data['value']
 
-		# handle imports
-		data = self._processImport(data)
+        return False
 
-		return data
+    def getValueProcessed(self, name):
+        data = self.getValue(name)
+        try:
+            data = json.loads(data)
+        except:
+            if app['debug']: traceback.print_exc()
+            return False
 
-	def getJson(self, name, recordKeys):
-		result = ""
-		data = self.getValue(name)
+        # handle imports
+        data = self._processImport(data)
 
-		if not data:
-			return json.dumps(result)
+        return data
 
-		dataJson = json.loads(data)
-		dataJson = self._fetchJson(dataJson, recordKeys.split(","))
-		if dataJson is not False:
-			result = dataJson
+    def getJson(self, name, recordKeys):
+        result = ""
+        data = self.getValue(name)
 
-		return json.dumps(result)
+        if not data:
+            return json.dumps(result)
 
-	def _fetchJson(self, jsonData, recordKeys):
-		for recordKey in recordKeys:
-			if recordKey not in jsonData:
-				return False
-			else:
-				jsonData = jsonData[recordKey]
+        dataJson = json.loads(data)
+        dataJson = self._fetchJson(dataJson, recordKeys.split(","))
+        if dataJson is not False:
+            result = dataJson
 
-		return jsonData
+        return json.dumps(result)
 
-	# process "import" on the given JSON object
-	def _processImport(self, data, limit = maxNestedCalls):
-		if app['debug']:
-			print "Processing import for", data
+    def _fetchJson(self, jsonData, recordKeys):
+        for recordKey in recordKeys:
+            if recordKey not in jsonData:
+                return False
+            else:
+                jsonData = jsonData[recordKey]
 
-		if limit < 1:
-			print "Too many recursive calls."
-			return data
+        return jsonData
 
-		if 'import' in data:
-			impName = data['import']
-			if app['debug']:
-				print "Recursing import on", impName
+    # process "import" on the given JSON object
+    def _processImport(self, data, limit = maxNestedCalls):
+        if app['debug']:
+            print "Processing import for", data
 
-			# TODO: Maybe rewrite to use an internal, more
-			# general 'getValueProcessed' routine here instead
-			# of recursing only on import.  In case that
-			# 'processing' of a value is more than just import,
-			# we possibly want that in the future.
-			impData = self.getValue(impName)
-			try:	
-				impData = json.loads(impData)
-			except:
-				if app['debug']: traceback.print_exc()
-				# XXX: Maybe return data here instead of fail?
-				return False
+        if limit < 1:
+            print "Too many recursive calls."
+            return data
 
-			impData = self._processImport(impData, limit - 1)
-			for key in impData:
-				if not key in data:
-					data[key] = impData[key]
+        if 'import' in data:
+            impName = data['import']
+            if app['debug']:
+                print "Recursing import on", impName
 
-			del data['import']
+            # TODO: Maybe rewrite to use an internal, more
+            # general 'getValueProcessed' routine here instead
+            # of recursing only on import.  In case that
+            # 'processing' of a value is more than just import,
+            # we possibly want that in the future.
+            impData = self.getValue(impName)
+            try:
+                impData = json.loads(impData)
+            except:
+                if app['debug']: traceback.print_exc()
+                # XXX: Maybe return data here instead of fail?
+                return False
 
-		return data
+            impData = self._processImport(impData, limit - 1)
+            for key in impData:
+                if not key in data:
+                    data[key] = impData[key]
+
+            del data['import']
+
+        return data
 
 

--- a/plugin/pluginDns.py
+++ b/plugin/pluginDns.py
@@ -7,247 +7,247 @@ import random
 
 class dnsResult(dict):
 
-	def add(self, domain, recType, record):
-		
-		if type(record) == unicode or type(record) == str:
-			record = [record]
+    def add(self, domain, recType, record):
 
-		if not recType in self:
-			self[recType] = []
+        if type(record) == unicode or type(record) == str:
+            record = [record]
 
-		self[recType].extend(record)
+        if not recType in self:
+            self[recType] = []
 
-	def add_raw(self, domain, recType, record):
+        self[recType].extend(record)
 
-		self[recType] = record
+    def add_raw(self, domain, recType, record):
 
-		#if type(record) == unicode or type(record) == str:
-		#	record = [record]
+        self[recType] = record
 
-		#print record
+        #if type(record) == unicode or type(record) == str:
+        #    record = [record]
 
-		#if not recType in self:
-		#	self[recType] = []
+        #print record
 
-		#self[recType].extend(dict(record))
-		#print self
+        #if not recType in self:
+        #    self[recType] = []
 
-	def toJsonForRPC(self):
+        #self[recType].extend(dict(record))
+        #print self
 
-		result = []
-		for key in self:
-			result = self[key]
-		
-		return json.dumps(result)
+    def toJsonForRPC(self):
+
+        result = []
+        for key in self:
+            result = self[key]
+
+        return json.dumps(result)
 
 
 class pluginDns(plugin.PluginThread):
-	name = 'dns'
-	options = {
-		'start':	['Launch at startup', 1],
-		'disable_ns_lookups':	['Disable remote lookups for NS records','0'],
-		#'host':		['Listen on ip', '127.0.0.1'],
-		#'port':		['Listen on port', 53],
-		#'resolver':	['Forward standard requests to', '8.8.8.8,8.8.4.4'],
-	}
-	helps = {
-		'getIp4':	[1, 1, '<domain>', 'Get a list of IPv4 for the domain'],
-		'getIp6':	[1, 1, '<domain>', 'Get a list of IPv6 for the domain'],
-		'getOnion':	[1, 1, '<domain>', 'Get the .onion for the domain'],
-		'getI2p':	[1, 1, '<domain>', 'Get the i2p config for the domain'],
-		'getFreenet':		[1, 1, '<domain>', 'Get the freenet config for the domain'],
-		'getFingerprint':	[1, 1, '<domain>', 'Get the sha1 of the certificate for the domain (deprecated)'],
-		'getTlsFingerprint':	[1, 3, '<domain> <protocol> <port>', 'Get the TLS information for the domain'],
-		'getNS':		[1, 1, '<domain>', 'Get a list of NS for the domain'],
-		'verifyFingerprint':	[1, 2, '<domain> <fingerprint>',
-					 'Verify if the fingerprint is'
-					 ' acceptable for the domain'],
-	}
-	handlers = []
+    name = 'dns'
+    options = {
+        'start':    ['Launch at startup', 1],
+        'disable_ns_lookups':    ['Disable remote lookups for NS records','0'],
+        #'host':        ['Listen on ip', '127.0.0.1'],
+        #'port':        ['Listen on port', 53],
+        #'resolver':    ['Forward standard requests to', '8.8.8.8,8.8.4.4'],
+    }
+    helps = {
+        'getIp4':    [1, 1, '<domain>', 'Get a list of IPv4 for the domain'],
+        'getIp6':    [1, 1, '<domain>', 'Get a list of IPv6 for the domain'],
+        'getOnion':    [1, 1, '<domain>', 'Get the .onion for the domain'],
+        'getI2p':    [1, 1, '<domain>', 'Get the i2p config for the domain'],
+        'getFreenet':        [1, 1, '<domain>', 'Get the freenet config for the domain'],
+        'getFingerprint':    [1, 1, '<domain>', 'Get the sha1 of the certificate for the domain (deprecated)'],
+        'getTlsFingerprint':    [1, 3, '<domain> <protocol> <port>', 'Get the TLS information for the domain'],
+        'getNS':        [1, 1, '<domain>', 'Get a list of NS for the domain'],
+        'verifyFingerprint':    [1, 2, '<domain> <fingerprint>',
+                     'Verify if the fingerprint is'
+                     ' acceptable for the domain'],
+    }
+    handlers = []
 
-	# process each sub dns plugin to see if one is interested by the request
-	def _resolve(self, domain, recType, result):
+    # process each sub dns plugin to see if one is interested by the request
+    def _resolve(self, domain, recType, result):
 
-		for handler in self.handlers:
-			#if request['handler'] not in handler.handle:
-			#	continue
+        for handler in self.handlers:
+            #if request['handler'] not in handler.handle:
+            #    continue
 
-			if recType not in handler.supportedMethods:
-				continue
+            if recType not in handler.supportedMethods:
+                continue
 
-			if 'dns' in handler.filters:
-				if not re.search(handler.filters['dns'], domain):
-					continue
+            if 'dns' in handler.filters:
+                if not re.search(handler.filters['dns'], domain):
+                    continue
 
-			if not handler._handle(domain, recType):
-				continue
+            if not handler._handle(domain, recType):
+                continue
 
-			handler._resolve(domain, recType, result)
-			return result
+            handler._resolve(domain, recType, result)
+            return result
 
-		return False
+        return False
 
-	def _getRecordForRPC(self, domain, recType):
-		result = dnsResult()
-		self._resolve(domain, recType, result)
-		return result.toJsonForRPC()
+    def _getRecordForRPC(self, domain, recType):
+        result = dnsResult()
+        self._resolve(domain, recType, result)
+        return result.toJsonForRPC()
 
-	def getIp4(self, domain):
-		result = self._getRecordForRPC(domain, 'getIp4')
-		# if we got an NS record because there is no IP we need to ask the NS server for the IP
-		if self.conf['disable_ns_lookups'] != '1':
-			if "ns" in result:
-				result = '["'+self._getIPv4FromNS(domain)+'"]'
+    def getIp4(self, domain):
+        result = self._getRecordForRPC(domain, 'getIp4')
+        # if we got an NS record because there is no IP we need to ask the NS server for the IP
+        if self.conf['disable_ns_lookups'] != '1':
+            if "ns" in result:
+                result = '["'+self._getIPv4FromNS(domain)+'"]'
 
-		return result
+        return result
 
-	def getIp6(self, domain):
-		result = self._getRecordForRPC(domain, 'getIp6')
-		# if we got an NS record because there is no IP we need to ask the NS server for the IP
-		if self.conf['disable_ns_lookups'] != '1':
-			if "ns" in result:
-				result = '["'+self._getIPv6FromNS(domain)+'"]'
+    def getIp6(self, domain):
+        result = self._getRecordForRPC(domain, 'getIp6')
+        # if we got an NS record because there is no IP we need to ask the NS server for the IP
+        if self.conf['disable_ns_lookups'] != '1':
+            if "ns" in result:
+                result = '["'+self._getIPv6FromNS(domain)+'"]'
 
-		return result
+        return result
 
-	def getOnion(self, domain):
-		return self._getRecordForRPC(domain, 'getOnion')
+    def getOnion(self, domain):
+        return self._getRecordForRPC(domain, 'getOnion')
 
-	def getI2p(self, domain):
-		return self._getRecordForRPC(domain, 'getI2p')
+    def getI2p(self, domain):
+        return self._getRecordForRPC(domain, 'getI2p')
 
-	def getFreenet(self, domain):
-		return self._getRecordForRPC(domain, 'getFreenet')
+    def getFreenet(self, domain):
+        return self._getRecordForRPC(domain, 'getFreenet')
 
-	def getFingerprint(self, domain):
-		return self._getRecordForRPC(domain, 'getFingerprint')
+    def getFingerprint(self, domain):
+        return self._getRecordForRPC(domain, 'getFingerprint')
 
-	def verifyFingerprint (self, domain, fpr):
-		allowable = self.getFingerprint (domain)
-		try:	
-			allowable = json.loads (allowable)
-		except:
-			if app['debug']: traceback.print_exc ()
-			return False
+    def verifyFingerprint (self, domain, fpr):
+        allowable = self.getFingerprint (domain)
+        try:
+            allowable = json.loads (allowable)
+        except:
+            if app['debug']: traceback.print_exc ()
+            return False
 
-		if not isinstance (allowable, list):
-			if app['debug']:
-				print "Fingerprint record", allowable, \
-				      "is not a list"
-			return False
+        if not isinstance (allowable, list):
+            if app['debug']:
+                print "Fingerprint record", allowable, \
+                      "is not a list"
+            return False
 
-		fpr = self._sanitiseFingerprint (fpr)
-		for a in allowable:
-			if self._sanitiseFingerprint (a) == fpr:
-				return True
+        fpr = self._sanitiseFingerprint (fpr)
+        for a in allowable:
+            if self._sanitiseFingerprint (a) == fpr:
+                return True
 
-		if app['debug']:
-			print "No acceptable fingerprint found."
-		return False
+        if app['debug']:
+            print "No acceptable fingerprint found."
+        return False
 
-	def getTlsFingerprint(self, domain, protocol, port):
-		#return tls data for the queried FQDN, or the first includeSubdomain tls record
-		result = self._getTls(domain)
+    def getTlsFingerprint(self, domain, protocol, port):
+        #return tls data for the queried FQDN, or the first includeSubdomain tls record
+        result = self._getTls(domain)
 
-		try:	
-			tls = json.loads(result)
-		except:
-			if app['debug']: traceback.print_exc()
-			return
+        try:
+            tls = json.loads(result)
+        except:
+            if app['debug']: traceback.print_exc()
+            return
 
-		try:
-			answer = tls[protocol][port]
-		except:
-			try:
-				answer = self._getSubDomainTlsFingerprint(domain, protocol, port)[protocol][port]
-			except:
-				return []
+        try:
+            answer = tls[protocol][port]
+        except:
+            try:
+                answer = self._getSubDomainTlsFingerprint(domain, protocol, port)[protocol][port]
+            except:
+                return []
 
-		result = dnsResult()
-		result.add(domain, 'getTlsFingerprint' , answer)
-		return result.toJsonForRPC()
+        result = dnsResult()
+        result.add(domain, 'getTlsFingerprint' , answer)
+        return result.toJsonForRPC()
 
-	def getNS(self, domain):
-		return self._getRecordForRPC(domain, 'getNS')
+    def getNS(self, domain):
+        return self._getRecordForRPC(domain, 'getNS')
 
-	def getTranslate(self, domain):
-		return self._getRecordForRPC(domain, 'getTranslate')
+    def getTranslate(self, domain):
+        return self._getRecordForRPC(domain, 'getTranslate')
 
-	def _getTls(self, domain):
-		return self._getRecordForRPC(domain, 'getTls')		
+    def _getTls(self, domain):
+        return self._getRecordForRPC(domain, 'getTls')
 
-	def _getNSServer(self,domain):
-		item = self.getNS(domain)
+    def _getNSServer(self,domain):
+        item = self.getNS(domain)
 
-		try:	
-			servers = json.loads(item)
-		except:
-			if app['debug']: traceback.print_exc()
-			return
+        try:
+            servers = json.loads(item)
+        except:
+            if app['debug']: traceback.print_exc()
+            return
 
-		server = servers[random.randrange(0, len(servers))]
-		return server
+        server = servers[random.randrange(0, len(servers))]
+        return server
 
-	def _getIPv4FromNS(self,domain):
-		#1 is the A record
-		server = self._getNSServer(domain)
-		
-		translate = self.getTranslate(domain)
-		
-		if translate != '[]':
-			try:	
-				translate = json.loads(translate)
-			except:
-				if app['debug']: traceback.print_exc()
-				return
+    def _getIPv4FromNS(self,domain):
+        #1 is the A record
+        server = self._getNSServer(domain)
 
-			domain = translate[0].rstrip('.')
+        translate = self.getTranslate(domain)
 
-		return app['services']['dns']._lookup(domain, 1 , server)[0]['data']
+        if translate != '[]':
+            try:
+                translate = json.loads(translate)
+            except:
+                if app['debug']: traceback.print_exc()
+                return
 
-	def _getIPv6FromNS(self,domain):
-		#28 is the AAAA record
-		server = self._getNSServer(domain)
-		
-		translate = self.getTranslate(domain)
-		
-		if translate != '[]':
-			try:	
-				translate = json.loads(translate)
-			except:
-				if app['debug']: traceback.print_exc()
-				return
+            domain = translate[0].rstrip('.')
 
-			domain = translate[0].rstrip('.')
+        return app['services']['dns']._lookup(domain, 1 , server)[0]['data']
 
-		return app['services']['dns']._lookup(domain, 28 , server)[0]['data']
+    def _getIPv6FromNS(self,domain):
+        #28 is the AAAA record
+        server = self._getNSServer(domain)
 
-	def _getSubDomainTlsFingerprint(self,domain,protocol,port):
-		#Get the first subdomain tls fingerprint that has the includeSubdomain flag turned on
-		for i in xrange(0,domain.count('.')):
+        translate = self.getTranslate(domain)
 
-			sub_domain = domain.split(".",i)[i]
-		
-			result = self._getTls(sub_domain)
+        if translate != '[]':
+            try:
+                translate = json.loads(translate)
+            except:
+                if app['debug']: traceback.print_exc()
+                return
 
-			try:	
-				tls = json.loads(result)
-			except:
-				if app['debug']: traceback.print_exc()
-				return
+            domain = translate[0].rstrip('.')
 
-			try:
-				if( tls[protocol][port][0][2] == 1):
-					return tls
-			except:
-				continue
+        return app['services']['dns']._lookup(domain, 28 , server)[0]['data']
 
-	# Sanitise a fingerprint for comparison.  This makes it
-	# all upper-case and removes colons and spaces.
-	def _sanitiseFingerprint (self, fpr):
-		#fpr = fpr.translate (None, ': ')
-		fpr = fpr.replace (":", "")
-		fpr = fpr.replace (" ", "")
-		fpr = fpr.upper ()
+    def _getSubDomainTlsFingerprint(self,domain,protocol,port):
+        #Get the first subdomain tls fingerprint that has the includeSubdomain flag turned on
+        for i in xrange(0,domain.count('.')):
 
-		return fpr
+            sub_domain = domain.split(".",i)[i]
+
+            result = self._getTls(sub_domain)
+
+            try:
+                tls = json.loads(result)
+            except:
+                if app['debug']: traceback.print_exc()
+                return
+
+            try:
+                if( tls[protocol][port][0][2] == 1):
+                    return tls
+            except:
+                continue
+
+    # Sanitise a fingerprint for comparison.  This makes it
+    # all upper-case and removes colons and spaces.
+    def _sanitiseFingerprint (self, fpr):
+        #fpr = fpr.translate (None, ': ')
+        fpr = fpr.replace (":", "")
+        fpr = fpr.replace (" ", "")
+        fpr = fpr.upper ()
+
+        return fpr

--- a/plugin/pluginGuiHttp.py
+++ b/plugin/pluginGuiHttp.py
@@ -4,25 +4,25 @@ import plugin
 #import json, base64, types, random, traceback
 
 class pluginGuiHttp(plugin.PluginThread):
-	name = 'guiHttp'
-	options = {
-		'start':	['Launch at startup', 1],
-		#'host':		['Listen on ip', '127.0.0.1'],
-		#'port':		['Listen on port', 53],
-		#'resolver':	['Forward standard requests to', '8.8.8.8,8.8.4.4'],
-	}
-	handlers = []
+    name = 'guiHttp'
+    options = {
+        'start':    ['Launch at startup', 1],
+        #'host':        ['Listen on ip', '127.0.0.1'],
+        #'port':        ['Listen on port', 53],
+        #'resolver':    ['Forward standard requests to', '8.8.8.8,8.8.4.4'],
+    }
+    handlers = []
 
-	def pLoadconfig(self):
-		app['services']['http'].handlers.append(self)
-	
-	# process each sub guiHttp plugin to see if one is interested by the request
-	def handle(self, request):
-		for handler in self.handlers:
-			if handler.handle(request):
-				return handler
+    def pLoadconfig(self):
+        app['services']['http'].handlers.append(self)
 
-		return False
-	
-	def do_GET(self, request):
-		return False
+    # process each sub guiHttp plugin to see if one is interested by the request
+    def handle(self, request):
+        for handler in self.handlers:
+            if handler.handle(request):
+                return handler
+
+        return False
+
+    def do_GET(self, request):
+        return False

--- a/plugin/pluginGuiHttpConfig.py
+++ b/plugin/pluginGuiHttpConfig.py
@@ -4,34 +4,34 @@ import plugin
 #import json, base64, types, random, traceback
 
 class pluginGuiHttpConfig(plugin.PluginThread):
-	name = 'guiHttpConfig'
-	options = {
-		'start':	['Launch at startup', 1],
-	}
-	depends = {'services': ['http']}
+    name = 'guiHttpConfig'
+    options = {
+        'start':    ['Launch at startup', 1],
+    }
+    depends = {'services': ['http']}
 
-	def pLoadconfig(self):
-		app['plugins']['guiHttp'].handlers.append(self)
-	
-	def handle(self, request):
-		if request.path[0:7] == '/config':
-			return True
+    def pLoadconfig(self):
+        app['plugins']['guiHttp'].handlers.append(self)
 
-		return False
-	
-	def do_GET(self, req):
-		#print "GET:", req.headers.get('Host'), req.path
+    def handle(self, request):
+        if request.path[0:7] == '/config':
+            return True
 
-		req.send_response(200)
-		req.send_header("Content-type", "text/html")
-		req.end_headers()
-		req.wfile.write("<html><head><title>Nmcontrol configuration</title></head>")
-		req.wfile.write("<body><p>This is the configuration plugin.</p>")
-		# If someone went to "http://something.somewhere.net/foo/bar/",
-		# then req.path equals "/foo/bar/".
-		req.wfile.write("<p>Domain is : %s</p>" % req.headers.get('Host'))
-		req.wfile.write("<p>You accessed path: %s</p>" % req.path)
-		req.wfile.write("</body></html>")
+        return False
 
-		return True
+    def do_GET(self, req):
+        #print "GET:", req.headers.get('Host'), req.path
+
+        req.send_response(200)
+        req.send_header("Content-type", "text/html")
+        req.end_headers()
+        req.wfile.write("<html><head><title>Nmcontrol configuration</title></head>")
+        req.wfile.write("<body><p>This is the configuration plugin.</p>")
+        # If someone went to "http://something.somewhere.net/foo/bar/",
+        # then req.path equals "/foo/bar/".
+        req.wfile.write("<p>Domain is : %s</p>" % req.headers.get('Host'))
+        req.wfile.write("<p>You accessed path: %s</p>" % req.path)
+        req.wfile.write("</body></html>")
+
+        return True
 

--- a/plugin/pluginMain.py
+++ b/plugin/pluginMain.py
@@ -3,53 +3,53 @@ import plugin
 import platform
 
 class pluginMain(plugin.PluginThread):
-	name = 'main'
-	options = {
-		'start':	['Launch at startup', (1, 0)[platform.system() == 'Windows']],
-		'debug':	['Debug mode', 0, '<0|1>'],
-		'daemon':	['Background mode', 1, '<0|1>'], 
-		#'plugins':	['Load only those plugins', 'main,data,rpc'],
-	}
+    name = 'main'
+    options = {
+        'start':    ['Launch at startup', (1, 0)[platform.system() == 'Windows']],
+        'debug':    ['Debug mode', 0, '<0|1>'],
+        'daemon':    ['Background mode', 1, '<0|1>'],
+        #'plugins':    ['Load only those plugins', 'main,data,rpc'],
+    }
 
-	def pStart(self):
-		app['plugins']['rpc'].start2()
+    def pStart(self):
+        app['plugins']['rpc'].start2()
 
-	def pStatus(self):
-		ret = ''
-		if self.running:
-			ret = "Plugin " + self.name + " running"
-		for plugin in app['plugins']:
-			if plugin != 'main' and app['plugins'][plugin].running:
-				ret += '\n' + app['plugins'][plugin].pStatus()
+    def pStatus(self):
+        ret = ''
+        if self.running:
+            ret = "Plugin " + self.name + " running"
+        for plugin in app['plugins']:
+            if plugin != 'main' and app['plugins'][plugin].running:
+                ret += '\n' + app['plugins'][plugin].pStatus()
 
-		return ret
+        return ret
 
-	def pStop(self):
-		self.running = False
-		app['plugins']['rpc'].stop()
-		if app['debug']:	print "Plugin %s stopping" %(self.name)
-		#for plugin in app['plugins']:
-		#	if app['plugins'][plugin].running == True:
-		#		app['plugins'][plugin].stop()
-		print "Plugin %s stopped" %(self.name)
+    def pStop(self):
+        self.running = False
+        app['plugins']['rpc'].stop()
+        if app['debug']:    print "Plugin %s stopping" %(self.name)
+        #for plugin in app['plugins']:
+        #    if app['plugins'][plugin].running == True:
+        #        app['plugins'][plugin].stop()
+        print "Plugin %s stopped" %(self.name)
 
-	def pRestart(self):
-		self.stop()
-		#self.start()
+    def pRestart(self):
+        self.stop()
+        #self.start()
 
-	def pLoadconfig(self):
-		self.conf['start'] = 1
-		if 'debug' in app:
-			self.conf['debug'] = app['debug']
+    def pLoadconfig(self):
+        self.conf['start'] = 1
+        if 'debug' in app:
+            self.conf['debug'] = app['debug']
 
-	def pHelp(self, args = []):
-		help = plugin.PluginThread.pHelp(self, args)
-		help += '\n\n'
+    def pHelp(self, args = []):
+        help = plugin.PluginThread.pHelp(self, args)
+        help += '\n\n'
 
-		help += '* Available plugins :'
-		for plug in app['plugins']:
-			if app['plugins'][plug].running == True:
-				help += '\n' + plug + ' help'
+        help += '* Available plugins :'
+        for plug in app['plugins']:
+            if app['plugins'][plug].running == True:
+                help += '\n' + plug + ' help'
 
-		return help
+        return help
 

--- a/plugin/pluginNamespaceDomain.py
+++ b/plugin/pluginNamespaceDomain.py
@@ -4,248 +4,248 @@ import DNS
 import json, base64, types, random, traceback
 
 class pluginNamespaceDomain(plugin.PluginThread):
-	name = 'domain'
-	options = {
-		'start':	['Launch at startup', 1],
-		#'resolver':	['Forward standard requests to', '8.8.8.8,8.8.4.4'],
-	}
-	depends = {'plugins': ['data', 'dns'],'services': ['dns']}
-	filters = {'dns': '.bit$|.tor$'}
-	handle  = ['dns']
+    name = 'domain'
+    options = {
+        'start':    ['Launch at startup', 1],
+        #'resolver':    ['Forward standard requests to', '8.8.8.8,8.8.4.4'],
+    }
+    depends = {'plugins': ['data', 'dns'],'services': ['dns']}
+    filters = {'dns': '.bit$|.tor$'}
+    handle  = ['dns']
 
-	maxNestedCalls = 10
-	supportedMethods = {
-		'getIp4'	: 'ip',
-		'getIp6'	: 'ip6',
-		'getOnion'	: 'tor',
-		'getI2p'	: 'i2p',
-		'getFreenet'	: 'freenet',
-		'getFingerprint': 'fingerprint',
-		'getTls': 'tls',
-		'getNS'		: 'ns',
-		'getTranslate'		: 'translate',
-	}
+    maxNestedCalls = 10
+    supportedMethods = {
+        'getIp4'    : 'ip',
+        'getIp6'    : 'ip6',
+        'getOnion'    : 'tor',
+        'getI2p'    : 'i2p',
+        'getFreenet'    : 'freenet',
+        'getFingerprint': 'fingerprint',
+        'getTls': 'tls',
+        'getNS'        : 'ns',
+        'getTranslate'        : 'translate',
+    }
 
-	def pLoadconfig(self):
-		app['plugins']['dns'].handlers.append(self)
+    def pLoadconfig(self):
+        app['plugins']['dns'].handlers.append(self)
 
-	# specific filter for this handler
-	def _handle(self, domain, recType):
-		return True
+    # specific filter for this handler
+    def _handle(self, domain, recType):
+        return True
 
-	def _prepareDomain(self, domain):
-		subdoms = domain.split(".")
-		gTLD = subdoms.pop()
-		gSLD = subdoms.pop()
+    def _prepareDomain(self, domain):
+        subdoms = domain.split(".")
+        gTLD = subdoms.pop()
+        gSLD = subdoms.pop()
 
-		return (gTLD, gSLD, subdoms, "d/" + gSLD)
+        return (gTLD, gSLD, subdoms, "d/" + gSLD)
 
-	def _resolve(self, domain, recType, result):
-		if app['debug']: print "Resolving :", domain, recType
+    def _resolve(self, domain, recType, result):
+        if app['debug']: print "Resolving :", domain, recType
 
-		if recType in self.supportedMethods:
-			recType = self.supportedMethods[recType]
+        if recType in self.supportedMethods:
+            recType = self.supportedMethods[recType]
 
-		gTLD, gSLD, subdoms, name = self._prepareDomain(domain)
+        gTLD, gSLD, subdoms, name = self._prepareDomain(domain)
 
                 # get value with imports already processed and already as JSON
-		nameData = app['plugins']['data'].getValueProcessed(name)
+        nameData = app['plugins']['data'].getValueProcessed(name)
 
-		# init
-		flatDomains = []
-		subdomains = subdoms[:]
-		subdomains.reverse()
-		# fingerprint and xxx records are valid for all sub-domains
-		parentIsValid = False
-		if recType in ['fingerprint']:
-			parentIsValid = True
+        # init
+        flatDomains = []
+        subdomains = subdoms[:]
+        subdomains.reverse()
+        # fingerprint and xxx records are valid for all sub-domains
+        parentIsValid = False
+        if recType in ['fingerprint']:
+            parentIsValid = True
 
-		# add asked domain first (ex: www.fr.dot-bit.bit)
-		flatDomains.append(subdomains[:])
-		# add each parent domain until root (ex: *.fr.dot-bit.bit, *.dot-bit.bit)
-		for sub in subdoms:
-			subdomains.pop()
-			subdomains.append("*")
-			flatDomains.append(subdomains[:])
-			subdomains.remove("*")
-			if parentIsValid: # (ex, if fingerprint: fr.dot-bit.bit, dot-bit.bit)
-				flatDomains.append(subdomains[:])
+        # add asked domain first (ex: www.fr.dot-bit.bit)
+        flatDomains.append(subdomains[:])
+        # add each parent domain until root (ex: *.fr.dot-bit.bit, *.dot-bit.bit)
+        for sub in subdoms:
+            subdomains.pop()
+            subdomains.append("*")
+            flatDomains.append(subdomains[:])
+            subdomains.remove("*")
+            if parentIsValid: # (ex, if fingerprint: fr.dot-bit.bit, dot-bit.bit)
+                flatDomains.append(subdomains[:])
 
-		# complete imports, alias, translate, etc
-		# starting from root domain to domain which has most sub-domains
-		flatDomains.reverse()
-		for subs in flatDomains:
-			nameData = self._expandSelectedRecord(nameData, subs)
+        # complete imports, alias, translate, etc
+        # starting from root domain to domain which has most sub-domains
+        flatDomains.reverse()
+        for subs in flatDomains:
+            nameData = self._expandSelectedRecord(nameData, subs)
 
-		# for each possible sub-domain, search for data
-		# starting at domain which has most sub-domains up to root domain
-		flatDomains.reverse()
-		if app['debug']: print "Possible domains :", flatDomains
-		for subs in flatDomains:
-			subData = self._fetchSubTree(nameData, subs)
-			if subData is not False:
-				if self._fetchNamecoinData(domain, recType, subs, subData, result):
-					if app['debug']: print "* result: ", json.dumps(result)
-					return result
+        # for each possible sub-domain, search for data
+        # starting at domain which has most sub-domains up to root domain
+        flatDomains.reverse()
+        if app['debug']: print "Possible domains :", flatDomains
+        for subs in flatDomains:
+            subData = self._fetchSubTree(nameData, subs)
+            if subData is not False:
+                if self._fetchNamecoinData(domain, recType, subs, subData, result):
+                    if app['debug']: print "* result: ", json.dumps(result)
+                    return result
 
-		if app['debug']: print "* result: ", json.dumps(result)
-		return result
-
-
-	def _fetchNamecoinData(self, domain, recType, subdoms, data, result):
-		if app['debug']: print "Fetching", recType, "for", domain, "in sub-domain", subdoms
-
-		if recType == 'tls':
-			if recType in data:
-				result.add_raw(domain, recType, data[recType])
-				return
-
-		# record found in data
-		if recType in data:
-			result.add(domain, recType, data[recType])
-			return True
-
-		# legacy compatibility with ip not in an "ip" record
-		if recType == 'ip' and ( type(data) == str or type(data) is unicode ):
-			result.add(domain, recType, data)
-			return True
-
-		if recType == 'ns' and ( type(data) == str or type(data) is unicode ):
-			result.add(domain, recType, data)
-			return True
-
-		# ns record in a dictionary, potentially with the translate option
-		if recType == 'ip' and 'ns' in data:
-			result.add(domain, recType, data)
-			return True
-
-		# legacy compatibility with "" in map instead of root
-		if recType == 'ip' and 'map' in data and '' in data['map']:
-			result.add(domain, recType, data['map'][''])
-			return True
-
-		if recType == 'ns' and 'map' in data and '' in data['map']:
-			result.add(domain, recType, data['map']['']['ns'])
-			return True
-
-		return False
-
-	# remove incompatible records (ns with ip, etc)
-	#def _cleanBadRecords(self, data):
-	#	pass
-
-	def _fetchSubTree(self, subData, subKeys):
-		for sub in subKeys:
-			if sub == '' and len(sub) == 0:
-				return subData
-			elif 'map' in subData and sub in subData['map']:
-				subData = subData['map'][sub]
-			else:
-				return False
-
-		return subData
-
-	# complete imports, alias, translate, etc
-	def _expandSelectedRecord(self, nameData, subDoms, limit = maxNestedCalls):
-		#print "Selected subs :", subDoms, nameData
-
-		limit -= 1
-		if limit < 0:
-			print "Too much recursive calls (%s+)" %(maxNestedCalls)
-			return nameData
-
-		subData = self._fetchSubTree(nameData, subDoms)
-
-		# sub-domain not found, nothing to do
-		if subData is False:
-			return nameData
-
-		# alias
-		if 'alias' in subData:
-			alias = subData['alias']
-			del subData['alias']
-
-			# resolve dependency
-			subAlias = alias.split(".")
-			nameData = self._expandSelectedRecord(nameData, subAlias, limit)
-
-			#print "Expanding '%s' alias to '%s' record" %(".".join(subDoms), alias)
-			aliasData = self._fetchSubTree(nameData, subAlias)
-			if aliasData is not False:
-				subData.update(aliasData)
-
-		#print "* nameData:", nameData
-		return nameData
-
-	def lookup(self, qdict) :
-		if qdict["domain"].endswith(".bit"):
-			return self._bitLookup(qdict)
-
-		if qdict["domain"].endswith(".tor"):
-			return self._torLookup(qdict)
+        if app['debug']: print "* result: ", json.dumps(result)
+        return result
 
 
-	def _bitLookup(self,qdict):
-		qtype = qdict['qtype']
-		if qtype == 1:
-			reqtype = "A"
-		if qtype == 2:
-			reqtype = "NS"
-		elif qtype == 5:
-			reqtype = "CNAME"
-		elif qtype == 16:
-			reqtype = "TXT"
-		elif qtype == 15:
-			reqtype = "MX"
-		elif qtype == 28:
-			reqtype = "AAAA"
-		elif qtype == 52:
-			reqtype = "TLSA"
+    def _fetchNamecoinData(self, domain, recType, subdoms, data, result):
+        if app['debug']: print "Fetching", recType, "for", domain, "in sub-domain", subdoms
+
+        if recType == 'tls':
+            if recType in data:
+                result.add_raw(domain, recType, data[recType])
+                return
+
+        # record found in data
+        if recType in data:
+            result.add(domain, recType, data[recType])
+            return True
+
+        # legacy compatibility with ip not in an "ip" record
+        if recType == 'ip' and ( type(data) == str or type(data) is unicode ):
+            result.add(domain, recType, data)
+            return True
+
+        if recType == 'ns' and ( type(data) == str or type(data) is unicode ):
+            result.add(domain, recType, data)
+            return True
+
+        # ns record in a dictionary, potentially with the translate option
+        if recType == 'ip' and 'ns' in data:
+            result.add(domain, recType, data)
+            return True
+
+        # legacy compatibility with "" in map instead of root
+        if recType == 'ip' and 'map' in data and '' in data['map']:
+            result.add(domain, recType, data['map'][''])
+            return True
+
+        if recType == 'ns' and 'map' in data and '' in data['map']:
+            result.add(domain, recType, data['map']['']['ns'])
+            return True
+
+        return False
+
+    # remove incompatible records (ns with ip, etc)
+    #def _cleanBadRecords(self, data):
+    #    pass
+
+    def _fetchSubTree(self, subData, subKeys):
+        for sub in subKeys:
+            if sub == '' and len(sub) == 0:
+                return subData
+            elif 'map' in subData and sub in subData['map']:
+                subData = subData['map'][sub]
+            else:
+                return False
+
+        return subData
+
+    # complete imports, alias, translate, etc
+    def _expandSelectedRecord(self, nameData, subDoms, limit = maxNestedCalls):
+        #print "Selected subs :", subDoms, nameData
+
+        limit -= 1
+        if limit < 0:
+            print "Too much recursive calls (%s+)" %(maxNestedCalls)
+            return nameData
+
+        subData = self._fetchSubTree(nameData, subDoms)
+
+        # sub-domain not found, nothing to do
+        if subData is False:
+            return nameData
+
+        # alias
+        if 'alias' in subData:
+            alias = subData['alias']
+            del subData['alias']
+
+            # resolve dependency
+            subAlias = alias.split(".")
+            nameData = self._expandSelectedRecord(nameData, subAlias, limit)
+
+            #print "Expanding '%s' alias to '%s' record" %(".".join(subDoms), alias)
+            aliasData = self._fetchSubTree(nameData, subAlias)
+            if aliasData is not False:
+                subData.update(aliasData)
+
+        #print "* nameData:", nameData
+        return nameData
+
+    def lookup(self, qdict) :
+        if qdict["domain"].endswith(".bit"):
+            return self._bitLookup(qdict)
+
+        if qdict["domain"].endswith(".tor"):
+            return self._torLookup(qdict)
 
 
-		#try the new API first, then fall back to map if it fails
-		if reqtype == "A":
-			#new style A request
-			answers = app['plugins']['dns'].getIp4(qdict["domain"])
-			if answers != '[]':
-				nameData = json.loads(answers)
-				answers = str(nameData[0])
-				#did we get an IP address or nothing?
-				if answers:
-					return answers
-			return
-		elif reqtype == "AAAA":
-			#new style AAAA request
-			answers = app['plugins']['dns'].getIp6(qdict["domain"])
-			if answers != '[]':
-				nameData = json.loads(answers)
-				answers = str(nameData[0])
-				#did we get an IP address or nothing?
-				if answers:
-					return answers
-			return
-		elif reqtype == "TLSA":
-			port = qdict["domain"].split(".")[0][1:]
-			protocol = qdict["domain"].split(".")[1][1:]
-			answers = app['plugins']['dns'].getTlsFingerprint(qdict["domain"], protocol, port)
-			answers = json.loads(answers)
-			return {"type":52, "class":1, "ttl":300, "data":answers}
-		return
+    def _bitLookup(self,qdict):
+        qtype = qdict['qtype']
+        if qtype == 1:
+            reqtype = "A"
+        if qtype == 2:
+            reqtype = "NS"
+        elif qtype == 5:
+            reqtype = "CNAME"
+        elif qtype == 16:
+            reqtype = "TXT"
+        elif qtype == 15:
+            reqtype = "MX"
+        elif qtype == 28:
+            reqtype = "AAAA"
+        elif qtype == 52:
+            reqtype = "TLSA"
 
-	def _torLookup(self,qdict):
 
-		answers = app['plugins']['dns'].getOnion(qdict["domain"])
-		if answers != '[]':
-			nameData = json.loads(answers)
-			answers = str(nameData[0])
-			#did we get an IP address or nothing?
-			if answers:
-				#if TXT record
-				if qdict['qtype'] == 16:
-					return {"type":16, "class":1, "ttl":300, "data":answers}
-				#if A record return a CNAME
-				elif qdict['qtype'] == 1:
-					return {"type":5, "class":1, "ttl":300, "data":answers}
-	
-		return
+        #try the new API first, then fall back to map if it fails
+        if reqtype == "A":
+            #new style A request
+            answers = app['plugins']['dns'].getIp4(qdict["domain"])
+            if answers != '[]':
+                nameData = json.loads(answers)
+                answers = str(nameData[0])
+                #did we get an IP address or nothing?
+                if answers:
+                    return answers
+            return
+        elif reqtype == "AAAA":
+            #new style AAAA request
+            answers = app['plugins']['dns'].getIp6(qdict["domain"])
+            if answers != '[]':
+                nameData = json.loads(answers)
+                answers = str(nameData[0])
+                #did we get an IP address or nothing?
+                if answers:
+                    return answers
+            return
+        elif reqtype == "TLSA":
+            port = qdict["domain"].split(".")[0][1:]
+            protocol = qdict["domain"].split(".")[1][1:]
+            answers = app['plugins']['dns'].getTlsFingerprint(qdict["domain"], protocol, port)
+            answers = json.loads(answers)
+            return {"type":52, "class":1, "ttl":300, "data":answers}
+        return
+
+    def _torLookup(self,qdict):
+
+        answers = app['plugins']['dns'].getOnion(qdict["domain"])
+        if answers != '[]':
+            nameData = json.loads(answers)
+            answers = str(nameData[0])
+            #did we get an IP address or nothing?
+            if answers:
+                #if TXT record
+                if qdict['qtype'] == 16:
+                    return {"type":16, "class":1, "ttl":300, "data":answers}
+                #if A record return a CNAME
+                elif qdict['qtype'] == 1:
+                    return {"type":5, "class":1, "ttl":300, "data":answers}
+
+        return
 

--- a/plugin/pluginRpc.py
+++ b/plugin/pluginRpc.py
@@ -4,185 +4,185 @@ import rpcClient
 import socket, json, threading, StringIO, sys, time, traceback
 
 class pluginRpc(plugin.PluginThread):
-	name = 'rpc'
-	options = {
-		'start':	['Launch at startup', 1],
-		'host':		['Listen on ip', '127.0.0.1', '<ip>'],
-		'port':		['Listen on port', 9000, '<port>'],
-	}
+    name = 'rpc'
+    options = {
+        'start':    ['Launch at startup', 1],
+        'host':        ['Listen on ip', '127.0.0.1', '<ip>'],
+        'port':        ['Listen on port', 9000, '<port>'],
+    }
 
-	def pStatus(self):
-		if self.running:
-			return "Plugin " + self.name + " running"
+    def pStatus(self):
+        if self.running:
+            return "Plugin " + self.name + " running"
 
-	def pStart(self):
-		self.threads = []
-		self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-		self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-		try:
-		 	self.s.bind((self.conf['host'], int(self.conf['port'])))
-			self.s.listen(1)
-			while self.running:
-				try:
-					c = rpcClientThread(self.s.accept(), app)
-					c.start()
-					self.threads.append(c)
-				except Exception as e:
-					if app['debug']: print "except:", e
-		except KeyboardInterrupt:
-			pass
-		except:
-			print "nmc-manager: unable to listen on port"
-			if app['debug']: traceback.print_exc()
+    def pStart(self):
+        self.threads = []
+        self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            self.s.bind((self.conf['host'], int(self.conf['port'])))
+            self.s.listen(1)
+            while self.running:
+                try:
+                    c = rpcClientThread(self.s.accept(), app)
+                    c.start()
+                    self.threads.append(c)
+                except Exception as e:
+                    if app['debug']: print "except:", e
+        except KeyboardInterrupt:
+            pass
+        except:
+            print "nmc-manager: unable to listen on port"
+            if app['debug']: traceback.print_exc()
 
-		# close all threads
-		if app['debug']: print "RPC stop listening"
-		self.s.close()
-		for c in self.threads:
-			c.join()
+        # close all threads
+        if app['debug']: print "RPC stop listening"
+        self.s.close()
+        for c in self.threads:
+            c.join()
 
-	def pStop(self):
-		if app['debug']: print "Plugin stop :", self.name
-		self.pSend(['exit'])
-		print "Plugin %s stopped" %(self.name)
+    def pStop(self):
+        if app['debug']: print "Plugin stop :", self.name
+        self.pSend(['exit'])
+        print "Plugin %s stopped" %(self.name)
 
-	def pSend(self, args):
-		if app['debug']: print "RPC - sending cmd :", args
-		r = rpcClient.rpcClient(self.conf['host'], int(self.conf['port']))
-		error, data = r.sendJson(args)
-		return error, data
+    def pSend(self, args):
+        if app['debug']: print "RPC - sending cmd :", args
+        r = rpcClient.rpcClient(self.conf['host'], int(self.conf['port']))
+        error, data = r.sendJson(args)
+        return error, data
 
 
-		try:
-			s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-			s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-			s.connect((self.conf['host'], int(self.conf['port'])))
-			s.sendall(json.dumps(args))
-			data = s.recv(4096)
-			s.close()
-			if app['debug']: print 'RPC - received data : ', repr(data)
-			data = json.loads(data)
-			if app['debug'] and 'result' in data and 'prints' in data['result']:
-				print data['result']['prints']
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.connect((self.conf['host'], int(self.conf['port'])))
+            s.sendall(json.dumps(args))
+            data = s.recv(4096)
+            s.close()
+            if app['debug']: print 'RPC - received data : ', repr(data)
+            data = json.loads(data)
+            if app['debug'] and 'result' in data and 'prints' in data['result']:
+                print data['result']['prints']
 
-			if data['error'] is None:
-				return data['result']['reply']
-			else:
-				return "ERROR: " + data['result']
+            if data['error'] is None:
+                return data['result']['reply']
+            else:
+                return "ERROR: " + data['result']
 
-		except Exception, e:
-			print "ERROR: unable to send request. Is program started ?"
-			print e
-			s.close()
-			return False
+        except Exception, e:
+            print "ERROR: unable to send request. Is program started ?"
+            print e
+            s.close()
+            return False
 
 
 class rpcClientThread(threading.Thread):
-	def __init__(self, (client, address), app):
-		self.client = client
-		self.client.settimeout(10)
-		self.address = address
-		self.size = 4096
-		threading.Thread.__init__(self)
+    def __init__(self, (client, address), app):
+        self.client = client
+        self.client.settimeout(10)
+        self.address = address
+        self.size = 4096
+        threading.Thread.__init__(self)
 
-	def run(self):
-		buff = ""
-		start = time.time()
-		while True:
-			try:
-				data = self.client.recv(self.size)
-			except socket.timeout as e:
-				break
-			self.client.settimeout(time.time() - start + 1)
-			if not data: break
-			buff += data
-			if len(data)%self.size != 0: break
-		(error, result) = self.computeJsonData(buff)
+    def run(self):
+        buff = ""
+        start = time.time()
+        while True:
+            try:
+                data = self.client.recv(self.size)
+            except socket.timeout as e:
+                break
+            self.client.settimeout(time.time() - start + 1)
+            if not data: break
+            buff += data
+            if len(data)%self.size != 0: break
+        (error, result) = self.computeJsonData(buff)
 
-		self.client.send('{"result":'+json.dumps(result)+',"error":'+json.dumps(error)+',"id":1}')
-		self.client.close()
+        self.client.send('{"result":'+json.dumps(result)+',"error":'+json.dumps(error)+',"id":1}')
+        self.client.close()
 
-	def computeJsonData(self, data):
-		if not data:
-			return (True, 'no data')
+    def computeJsonData(self, data):
+        if not data:
+            return (True, 'no data')
 
-		#print "computeJsonData:", data
-		data = json.loads(data)
-		
-		if data['method'] == 'exit' or 'exit' in data['params']:
-			return (True, 'exit')
+        #print "computeJsonData:", data
+        data = json.loads(data)
 
-		return self.computeData([data['method'], data['params']])
+        if data['method'] == 'exit' or 'exit' in data['params']:
+            return (True, 'exit')
 
-	def computeData(self, args):
-		#if app['debug']: print "Received data :", args
+        return self.computeData([data['method'], data['params']])
 
-		# check for default plugin
-		if len(args[1]) == 0: args = ['main', [args[0]]]
+    def computeData(self, args):
+        #if app['debug']: print "Received data :", args
 
-		plugin = args[0]
-		params = args[1]
-		method = params.pop(0)
-		#print "Plugin:", plugin
-		#print "Method:", method
-		#print "Params:", params
+        # check for default plugin
+        if len(args[1]) == 0: args = ['main', [args[0]]]
 
-		if plugin not in app['plugins']:
-			return (True, 'Plugin "' + plugin + '" not allowed')
-		if not app['plugins'][plugin].running and params[0] != 'start':
-			return (True, 'Plugin "' + plugin + '" not started')
+        plugin = args[0]
+        params = args[1]
+        method = params.pop(0)
+        #print "Plugin:", plugin
+        #print "Method:", method
+        #print "Params:", params
 
-		if method == 'start': method = 'start2'
+        if plugin not in app['plugins']:
+            return (True, 'Plugin "' + plugin + '" not allowed')
+        if not app['plugins'][plugin].running and params[0] != 'start':
+            return (True, 'Plugin "' + plugin + '" not started')
 
-		# reply before being blocked by non threaded start
-		# TODO : recreate thread for the start command and delete when stop
-		if not app['plugins'][plugin].running and method == 'start2':
-			self.client.send('{"result":'+json.dumps({'reply':True, 'prints':'Restarting '+plugin+''})+',"error":'+json.dumps(None)+',"id":1}');
+        if method == 'start': method = 'start2'
 
-		# reply before closing connection
-		if plugin == 'rpc' and method == 'restart':
-			self.client.send('{"result":'+json.dumps({'reply':True, 'prints':'Restarting rpc'})+',"error":'+json.dumps(None)+',"id":1}');
+        # reply before being blocked by non threaded start
+        # TODO : recreate thread for the start command and delete when stop
+        if not app['plugins'][plugin].running and method == 'start2':
+            self.client.send('{"result":'+json.dumps({'reply':True, 'prints':'Restarting '+plugin+''})+',"error":'+json.dumps(None)+',"id":1}');
 
-		# can't call private/protected methods
-		if method[0] == '_':
-			if app['debug']: print "RPC - forbidden cmd :", args
-			return (True, 'Method "' + params[0] + '" not allowed')
+        # reply before closing connection
+        if plugin == 'rpc' and method == 'restart':
+            self.client.send('{"result":'+json.dumps({'reply':True, 'prints':'Restarting rpc'})+',"error":'+json.dumps(None)+',"id":1}');
 
-		# help asked on a method
-		if 'help' in params:
-			params.remove('help')
-			params.insert(0, method)
-			method = 'help'
+        # can't call private/protected methods
+        if method[0] == '_':
+            if app['debug']: print "RPC - forbidden cmd :", args
+            return (True, 'Method "' + params[0] + '" not allowed')
 
-		# help thrown due to incorrect use of method
-		if method in app['plugins'][plugin].helps and len(params) not in range(app['plugins'][plugin].helps[method][0], app['plugins'][plugin].helps[method][1]+1):
-			params.insert(0, method)
-			method = 'help'
+        # help asked on a method
+        if 'help' in params:
+            params.remove('help')
+            params.insert(0, method)
+            method = 'help'
 
-		if app['debug']: print "RPC - executing cmd :", plugin, method, params
+        # help thrown due to incorrect use of method
+        if method in app['plugins'][plugin].helps and len(params) not in range(app['plugins'][plugin].helps[method][0], app['plugins'][plugin].helps[method][1]+1):
+            params.insert(0, method)
+            method = 'help'
 
-		# capture stdout
-		capture = StringIO.StringIO()
-		#sys.stdout = capture
+        if app['debug']: print "RPC - executing cmd :", plugin, method, params
 
-		try:
-			methodRpc = getattr(app['plugins'][plugin], '_rpc')
-			result = methodRpc(method, *params)
-		except AttributeError, e:
-			if app['debug']: traceback.print_exc()
-			return (True, 'Method "' + method + '" not supported by plugin "' + plugin + '"')
-		except Exception, e:
-			if app['debug']: traceback.print_exc()
-			return (True, 'Exception : ' + str(e))
+        # capture stdout
+        capture = StringIO.StringIO()
+        #sys.stdout = capture
 
-		# restore stdout
-		sys.stdout = sys.__stdout__
-		prints = capture.getvalue()
-		capture.close()
+        try:
+            methodRpc = getattr(app['plugins'][plugin], '_rpc')
+            result = methodRpc(method, *params)
+        except AttributeError, e:
+            if app['debug']: traceback.print_exc()
+            return (True, 'Method "' + method + '" not supported by plugin "' + plugin + '"')
+        except Exception, e:
+            if app['debug']: traceback.print_exc()
+            return (True, 'Exception : ' + str(e))
 
-		#if result is None:
-		#	result = 'No data'
+        # restore stdout
+        sys.stdout = sys.__stdout__
+        prints = capture.getvalue()
+        capture.close()
 
-		return (None, {'reply': result, 'prints': prints})
+        #if result is None:
+        #    result = 'No data'
+
+        return (None, {'reply': result, 'prints': prints})
 
 

--- a/service/serviceDNS.py
+++ b/service/serviceDNS.py
@@ -5,55 +5,55 @@ import dnsServer
 import random, re
 
 class serviceDNS(plugin.PluginThread):
-	name = 'dns'
-	options = {
-		'start':	['Launch at startup', 1],
-		'host':		['Listen on ip', '127.0.0.1'],
-		'port':		['Listen on port', 53],
-		'resolver':	['Forward standard requests to', '8.8.8.8,8.8.4.4'],
-		'disable_standard_lookups': ['Disable lookups for standard domains','0']
-	}
-	srv = None
+    name = 'dns'
+    options = {
+        'start':    ['Launch at startup', 1],
+        'host':        ['Listen on ip', '127.0.0.1'],
+        'port':        ['Listen on port', 53],
+        'resolver':    ['Forward standard requests to', '8.8.8.8,8.8.4.4'],
+        'disable_standard_lookups': ['Disable lookups for standard domains','0']
+    }
+    srv = None
 
-	def pStart(self):
-		self.servers = self.conf['resolver'].split(',')
-		if self.srv is None:
-			self.srv = dnsServer.DnsServer()
-			self.srv.start()
-		if app['debug']: print "Service %s started" %(self.name)
-		return True
-	
-	def pStop(self):
-		if self.srv is not None:
-			self.srv.stop()
-			self.srv = None
-		if app['debug']: print "Service %s stopped" %(self.name)
-		return True
+    def pStart(self):
+        self.servers = self.conf['resolver'].split(',')
+        if self.srv is None:
+            self.srv = dnsServer.DnsServer()
+            self.srv.start()
+        if app['debug']: print "Service %s started" %(self.name)
+        return True
 
-	def lookup(self, qdict) :
-		if app['debug']: print 'Lookup:', qdict
-		#for service, value in self.services.iteritems():
-		#	if re.search(value['filter'], qdict["domain"]):
-		#		return app['plugins'][service].lookup(qdict)
-		if qdict["domain"].endswith(".bit") or qdict["domain"].endswith(".tor"):
-			return app['plugins']['domain'].lookup(qdict)
-		if self.conf['disable_standard_lookups'] == '1':
-			return []
-		return self._lookup(qdict["domain"],qdict["qtype"])
+    def pStop(self):
+        if self.srv is not None:
+            self.srv.stop()
+            self.srv = None
+        if app['debug']: print "Service %s stopped" %(self.name)
+        return True
 
-	def _lookup(self, domain, qtype=1, server = ''):
-		#make sure the server string is a string and not unicode, otherwise the DNS library fails to resolve it
-		server = str(server)
+    def lookup(self, qdict) :
+        if app['debug']: print 'Lookup:', qdict
+        #for service, value in self.services.iteritems():
+        #    if re.search(value['filter'], qdict["domain"]):
+        #        return app['plugins'][service].lookup(qdict)
+        if qdict["domain"].endswith(".bit") or qdict["domain"].endswith(".tor"):
+            return app['plugins']['domain'].lookup(qdict)
+        if self.conf['disable_standard_lookups'] == '1':
+            return []
+        return self._lookup(qdict["domain"],qdict["qtype"])
 
-		if server == '':
-			server = self.servers[random.randrange(0, len(self.servers)-1)]
+    def _lookup(self, domain, qtype=1, server = ''):
+        #make sure the server string is a string and not unicode, otherwise the DNS library fails to resolve it
+        server = str(server)
 
-		if app['debug']: print "Fetching IP Address for: ", domain, "with NS Server:", server
+        if server == '':
+            server = self.servers[random.randrange(0, len(self.servers)-1)]
 
-		x = DNS.Request(server=server)
-		result = x.req(name=domain, qtype=qtype).answers
+        if app['debug']: print "Fetching IP Address for: ", domain, "with NS Server:", server
 
-		if app['debug']: print "* result: ", result
+        x = DNS.Request(server=server)
+        result = x.req(name=domain, qtype=qtype).answers
 
-		return result
+        if app['debug']: print "* result: ", result
+
+        return result
 

--- a/service/serviceHTTP.py
+++ b/service/serviceHTTP.py
@@ -3,80 +3,80 @@ import plugin, time, BaseHTTPServer
 
 class serviceHTTP(plugin.PluginThread):
 #class pluginServiceHTTP(plugin.PluginThread):
-	name = 'http'
-	options = {
-		'start':	['Launch at startup', 1],
-		'host':		['Listen on ip', '127.0.0.2'],
-		'port':		['Listen on port', 80],
-	}
-	handlers = []
-	srv = None
+    name = 'http'
+    options = {
+        'start':    ['Launch at startup', 1],
+        'host':        ['Listen on ip', '127.0.0.2'],
+        'port':        ['Listen on port', 80],
+    }
+    handlers = []
+    srv = None
 
-	def pStart(self):
-		if self.srv is None:
-			try:
-				self.srv = BaseHTTPServer.HTTPServer((self.conf['host'], int(self.conf['port'])), MyHandler)
-				self.srv.app = app
-				self.srv.serve_forever()
-			except Exception as e:
-				print "ERROR: Unable to start HTTP server (%s)" % e
-		if app['debug']: print "Service %s started" %(self.name)
-		return True
-	
-	def pStop(self):
-		if self.srv is not None:
-			self.srv.server_close()
-			self.srv = None
-		if app['debug']: print "Service %s stopped" %(self.name)
-		return True
+    def pStart(self):
+        if self.srv is None:
+            try:
+                self.srv = BaseHTTPServer.HTTPServer((self.conf['host'], int(self.conf['port'])), MyHandler)
+                self.srv.app = app
+                self.srv.serve_forever()
+            except Exception as e:
+                print "ERROR: Unable to start HTTP server (%s)" % e
+        if app['debug']: print "Service %s started" %(self.name)
+        return True
+
+    def pStop(self):
+        if self.srv is not None:
+            self.srv.server_close()
+            self.srv = None
+        if app['debug']: print "Service %s stopped" %(self.name)
+        return True
 
 class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
-	def do_HEAD(req):
-		req.send_response(200)
-		req.send_header("Content-type", "text/html")
-		req.end_headers()
+    def do_HEAD(req):
+        req.send_response(200)
+        req.send_header("Content-type", "text/html")
+        req.end_headers()
 
-	def do_GET(req):
-		self = req.server.app['services']['http']
+    def do_GET(req):
+        self = req.server.app['services']['http']
 
-		isHandled = False
-		for handler in self.handlers:
-			httpHandler = handler.handle(req)
-			if httpHandler is not False:
-				isHandled = httpHandler.do_GET(req)
-				if isHandled:
-					return
+        isHandled = False
+        for handler in self.handlers:
+            httpHandler = handler.handle(req)
+            if httpHandler is not False:
+                isHandled = httpHandler.do_GET(req)
+                if isHandled:
+                    return
 
-		MyHandler.default_GET(req)
-	
-	def default_GET(req):
-		"""Respond to a GET request."""
-		#if req.headers.get('Host').endswith('.tor'):
-		#	req.server.app['plugins']['tor'].httpHandle(s)
-		#	return
+        MyHandler.default_GET(req)
 
-		req.send_response(200)
-		req.send_header("Content-type", "text/html")
-		req.end_headers()
-		req.wfile.write("<html><head><title>Nmcontrol</title></head>")
-		req.wfile.write("<body><p>This is the default page of nmcontrol.</p>")
-		# If someone went to "http://something.somewhere.net/foo/bar/",
-		# then req.path equals "/foo/bar/".
-		req.wfile.write("<p>Domain is : %s</p>" % req.headers.get('Host'))
-		req.wfile.write("<p>You accessed path: %s</p>" % req.path)
-		req.wfile.write("</body></html>")
+    def default_GET(req):
+        """Respond to a GET request."""
+        #if req.headers.get('Host').endswith('.tor'):
+        #    req.server.app['plugins']['tor'].httpHandle(s)
+        #    return
+
+        req.send_response(200)
+        req.send_header("Content-type", "text/html")
+        req.end_headers()
+        req.wfile.write("<html><head><title>Nmcontrol</title></head>")
+        req.wfile.write("<body><p>This is the default page of nmcontrol.</p>")
+        # If someone went to "http://something.somewhere.net/foo/bar/",
+        # then req.path equals "/foo/bar/".
+        req.wfile.write("<p>Domain is : %s</p>" % req.headers.get('Host'))
+        req.wfile.write("<p>You accessed path: %s</p>" % req.path)
+        req.wfile.write("</body></html>")
 
 
 
 if __name__ == '__main__':
-	server_class = BaseHTTPServer.HTTPServer
-	httpd = server_class((HOST_NAME, PORT_NUMBER), MyHandler)
-	print time.asctime(), "Server Starts - %s:%s" % (HOST_NAME, PORT_NUMBER)
-	try:
-		httpd.serve_forever()
-	except KeyboardInterrupt:
-		pass
-	httpd.server_close()
-	print time.asctime(), "Server Stops - %s:%s" % (HOST_NAME, PORT_NUMBER)
+    server_class = BaseHTTPServer.HTTPServer
+    httpd = server_class((HOST_NAME, PORT_NUMBER), MyHandler)
+    print time.asctime(), "Server Starts - %s:%s" % (HOST_NAME, PORT_NUMBER)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+    print time.asctime(), "Server Stops - %s:%s" % (HOST_NAME, PORT_NUMBER)
 


### PR DESCRIPTION
Convert tabs to python standard (four spaces) in all files. Also remove trailing spaces. Indentation should be the same over all files now. 
I noticed in some places there were tabs before comments - there should be two spaces before and one space after the hash character - now there are four spaces instead of the tabs but IMHO this is only an aesthetic problem.

Hope you can agree to this as it looks like such a huge change. But if I got it right nothing of relevance for the Python interpreter has changed. The indentation stuff just kept causing me trouble.
