### PR TITLE
Fix a command line flag issue

### DIFF
--- a/nmcontrol.py
+++ b/nmcontrol.py
@@ -63,6 +63,7 @@ def main():
                     print "Exception when loading "+modType, module, ":", e
 
     # parse command line options
+    # Note: There should not be plugins and services with the same name    
     (options, app['args']) = app['parser'].parse_args()
     if app['debug']: print "Cmdline args:", app['args']
     if app['debug']: print "Cmdline options:", options


### PR DESCRIPTION
This should fix https://github.com/namecoin/nmcontrol/issues/26 .  Can everyone please test this for regressions relating to command line option processing?  I don't expect it to cause problems, but it definitely changes the data that services are receiving.

In particular, the most likely command line option to be adversely affected is --dns.disable_ns_lookups=0 and/or --dns.disable_ns_lookups=1 .  That option seems to work fine for me.  But additional testing would be appreciated.
