### PR TITLE
Auto dns config win

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -7,3 +7,7 @@ mkdir dist\nmcontrol\service\
 xcopy lib dist\nmcontrol\lib /s /e /h
 xcopy plugin dist\nmcontrol\plugin /s /e /h
 xcopy service dist\nmcontrol\service /s /e /h
+
+copy local_bit_dns_start.reg dist\nmcontrol\
+copy local_bit_dns_stop.reg dist\nmcontrol\
+copy nmcontrol_auto_dns.bat dist\nmcontrol\

--- a/local_bit_dns_start.reg
+++ b/local_bit_dns_start.reg
@@ -1,0 +1,8 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\System\CurrentControlSet\services\Dnscache\Parameters\DnsPolicyConfig\NMControl]
+"ConfigOptions"=dword:00000008
+"Name"=hex(7):2e,00,62,00,69,00,74,00,00,00,00,00
+"IPSECCARestriction"=""
+"GenericDNSServers"="127.0.0.1"
+"Version"=dword:00000002

--- a/local_bit_dns_stop.reg
+++ b/local_bit_dns_stop.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_LOCAL_MACHINE\System\CurrentControlSet\services\Dnscache\Parameters\DnsPolicyConfig\NMControl]

--- a/nmcontrol_auto_dns.bat
+++ b/nmcontrol_auto_dns.bat
@@ -1,0 +1,12 @@
+@echo off
+
+echo Configuring Windows DNS Policy for .bit...
+regedit /s local_bit_dns_start.reg
+
+echo Starting NMControl...
+nmcontrol.exe start --daemon=0
+
+echo NMControl has exited, reverting Windows DNS Policy settings...
+regedit /s local_bit_dns_stop.reg
+
+echo Good bye!


### PR DESCRIPTION
DNS settings can now be automatically configured on Windows (launch using nmcontrol_auto_dns.bat instead of nmcontrol.exe).  Tested and working for me on Win8.  Reportedly this method does not work on Win7 and below.  Please test and make sure it works properly for you before merging.