### PR TITLE
Changed shebang line to use env

### DIFF
--- a/nmcontrol.py
+++ b/nmcontrol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 __version__ = '0.8'
 


### PR DESCRIPTION
/usr/bin/env is more portable so alternate python locations can be used.
