### PR TITLE
Support REST API as backend.

### DIFF
--- a/lib/backendDataRest.py
+++ b/lib/backendDataRest.py
@@ -1,19 +1,84 @@
 from common import *
+from utils import *
 
+import hashlib
 import httplib
 import json
+import socket
+import ssl
 import urllib
 import urlparse
+
+class MyHTTPSConnection(httplib.HTTPConnection):
+    """
+    Make a HTTPS connection, but support checking the
+    server's certificate fingerprint.
+    """
+
+    def __init__(self, host, port):
+        httplib.HTTPConnection.__init__(self, host, port)
+
+    def connect(self):
+        sock = socket.create_connection((self.host, self.port))
+        self.sock = ssl.wrap_socket(sock)
+
+    def verifyCert(self, fprs):
+        """
+        Check whether the server's certificate fingerprint
+        matches the given one.  'fprs' should be a dict with
+        keys corresponding to digest methods and values being
+        the digest value.
+        """
+
+        hasher = None
+        fpr = None
+        
+        if 'sha256' in fprs:
+            hasher = hashlib.sha256()
+            fpr = fprs['sha256']
+        elif 'sha1' in fprs:
+            hasher = hashlib.sha1()
+            fpr = fprs['sha1']
+
+        # Be strict here.  If this routine is called, it means that at least
+        # some parameters were given in the REST URI.  If we can't verify the
+        # fingerprint because the parameters were invalid, fail to make sure
+        # that the user does not expect security but doesn't get it due
+        # to an operational mistake.
+        if hasher is None:
+            if app['debug']:
+                print "no recognised fingerprint given, failing check"
+            return False
+        assert fpr is not None
+
+        cert = self.sock.getpeercert(True)
+        hasher.update(cert)
+        digest = hasher.hexdigest()
+
+        if sanitiseFingerprint(digest) != sanitiseFingerprint(fpr):
+            if app['debug']:
+                print "Fingerprint mismatch:"
+                print "  expected:", fpr
+                print "  got:", digest
+            return False
+
+        return True
 
 class backendData():
     validURL = False
 
     def __init__(self, conf):
         url = urlparse.urlparse(conf)
-        if url.scheme == 'http':
+        if url.scheme == 'http' or url.scheme == 'https':
             self.validURL = True
+            self.tls = (url.scheme == 'https')
             self.host = url.hostname
             self.port = url.port
+
+            if url.params == '':
+                self.fprs = None
+            else:
+                self.fprs = self._parseFprOptions(url.params)
         elif app['debug']:
             print "Unsupported scheme for REST URL:", url.scheme
 
@@ -34,8 +99,15 @@ class backendData():
 
     def _queryHttpGet(self, path):
         assert self.validURL
-        conn = httplib.HTTPConnection(self.host, self.port)
+        if self.tls:
+            conn = MyHTTPSConnection(self.host, self.port)
+        else:
+            conn = httplib.HTTPConnection(self.host, self.port)
         conn.request('GET', path)
+
+        if self.tls and (self.fprs is not None):
+            if not conn.verifyCert(self.fprs):
+                return "TLS fingerprint wrong", None
 
         res = conn.getresponse()
         if res.status != 200:
@@ -46,3 +118,19 @@ class backendData():
 
         return res.read()
 
+    def _parseFprOptions(self, s):
+        """
+        Parse the REST URI params string that includes (optionally)
+        the TLS certificate fingerprints.
+        """
+
+        pieces = s.split(',')
+
+        res = {}
+        for p in pieces:
+            parts = p.split('=', 1)
+            assert len (parts) <= 2
+            if len (parts) == 2:
+                res[parts[0]] = parts[1]
+
+        return res

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,0 +1,13 @@
+def sanitiseFingerprint(fpr):
+    """
+    Sanitise a fingerprint (of a TLS certificate, for instance) for
+    comparison.  This removes colons, spaces and makes the string
+    upper case.
+    """
+
+    #fpr = fpr.translate (None, ': ')
+    fpr = fpr.replace (":", "")
+    fpr = fpr.replace (" ", "")
+    fpr = fpr.upper ()
+
+    return fpr

--- a/plugin/pluginData.py
+++ b/plugin/pluginData.py
@@ -21,7 +21,7 @@ class pluginData(plugin.PluginThread):
         {'update.freq':        ['Update data if older than', '30m', '<number>[h|m|s]']},
         {'update.file':        ['Update data from file ', 'data' + os.sep + 'namecoin.dat']},
         {'update.namecoin':    ['Path of namecoin.conf', platformDep.getNamecoinDir() + os.sep + 'namecoin.conf']},
-        {'update.rest':        ['REST API to query', 'http://localhost:8336']},
+        {'update.rest':        ['REST API to query', 'http://localhost:8336/']},
 
         {'export.mode':        ['Export mode', 'none', '<none|all>']},
         {'export.to':        ['Export data to', 'file']},

--- a/plugin/pluginDns.py
+++ b/plugin/pluginDns.py
@@ -1,4 +1,5 @@
 from common import *
+from utils import *
 import plugin
 #import DNS
 #import json, base64, types, random, traceback
@@ -184,9 +185,9 @@ class pluginDns(plugin.PluginThread):
                       "is not a list"
             return False
 
-        fpr = self._sanitiseFingerprint (fpr)
+        fpr = sanitiseFingerprint (fpr)
         for a in allowable:
-            if self._sanitiseFingerprint (a) == fpr:
+            if sanitiseFingerprint (a) == fpr:
                 return True
 
         if app['debug']:
@@ -289,13 +290,3 @@ class pluginDns(plugin.PluginThread):
                     return tls
             except:
                 continue
-
-    # Sanitise a fingerprint for comparison.  This makes it
-    # all upper-case and removes colons and spaces.
-    def _sanitiseFingerprint (self, fpr):
-        #fpr = fpr.translate (None, ': ')
-        fpr = fpr.replace (":", "")
-        fpr = fpr.replace (" ", "")
-        fpr = fpr.upper ()
-
-        return fpr


### PR DESCRIPTION
Allow to use a REST API server as backend for NMControl.  Supports both HTTP and HTTPS connections, and allows to optionally specify the expected TLS certificate.  This makes it safe to use with a remote host.

Note, though, that I'm not a TLS nor Python expert.  So I can't guarantee that the code is safe (but I expect it to be, review welcome).

See https://github.com/namecoin/nmcontrol/issues/48.
