### PR TITLE
Fix relative import use by using path to script

### DIFF
--- a/nmcontrol.py
+++ b/nmcontrol.py
@@ -48,7 +48,7 @@ def main():
 
     # init service & plugins
     for modType in ['service', 'plugin']:
-        modules = dircache.listdir(modType)
+        modules = dircache.listdir(os.path.join(app['path']['app'], modType))
         if modType == 'plugin': modules.remove('pluginMain.py')
         for module in modules:
             if re.match("^"+modType+".*.py$", module):


### PR DESCRIPTION
This fixes #3. I was actually able to use `app['path']['app']` as the path to the directory of the script instead of creating a new variable to hold the path to the directory of the script.
