### PR TITLE
Set "disable_standard_lookups" to a default of 1

### DIFF
--- a/service/serviceDNS.py
+++ b/service/serviceDNS.py
@@ -11,7 +11,7 @@ class serviceDNS(plugin.PluginThread):
         'host':        ['Listen on ip', '127.0.0.1'],
         'port':        ['Listen on port', 53],
         'resolver':    ['Forward standard requests to', '8.8.8.8,8.8.4.4'],
-        'disable_standard_lookups': ['Disable lookups for standard domains','0']
+        'disable_standard_lookups': ['Disable lookups for standard domains','1']
     }
     srv = None
 


### PR DESCRIPTION
We should not send all lookups to Google by default.