### PR TITLE
dnsServer: log errors also in non-debug mode

### DIFF
--- a/lib/dnsServer/__init__.py
+++ b/lib/dnsServer/__init__.py
@@ -104,7 +104,7 @@ class DnsServer(threading.Thread):
                     exception_rcode = 3
                     raise Exception("query is not for our domain: %s" % ".".join(question))
             except:
-                log.debug("oops", exc_info=1)
+                log.exception("dnsServer: lookup failed")
                 if not self.running:
                     continue
                 if qid:


### PR DESCRIPTION
If things go wrong the exception should go into the log so users can fix the problem.